### PR TITLE
aws-panopticon() accepts pipes in command

### DIFF
--- a/lib/misc-functions
+++ b/lib/misc-functions
@@ -20,9 +20,9 @@ aws-panopticon() {
   for aws_account_id in $aws_account_ids; do
     local assumed_env=$(sts-assume-role "arn:aws:iam::${aws_account_id}:role/${assumed_role_name}")
     [[ -z "$assumed_env" ]] && continue # AWSCLI prints error if assuming role fails
-    local aws_account_alias="$(eval $assumed_env aws-account-alias)"
+    local aws_account_alias="$(export $assumed_env && aws-account-alias)"
     echo "#account=$aws_account_id alias=${aws_account_alias}"
-    if ! output="$(eval $assumed_env $cmd)"; then
+    if ! output="$(export $assumed_env && eval $cmd)"; then
       : # something went wrong
     fi
     [ -z "$output" ] || printf '%s\n\n' "${output%$'\n'}"


### PR DESCRIPTION
Previously, something like this would fail because the assumed
role would only be available to the first command before the pipe:

```
$ echo 1234567890 | aws-panopticon 'stacks | grep foo | stack-tags'
```

One `eval` has been removed but we've kept the other for now because
we need it for the pipes in the user supplied command to work.