### PR TITLE
Simpler shared functions

### DIFF
--- a/aliases
+++ b/aliases
@@ -114,6 +114,7 @@ alias rds-db-clusters='~/.bash-my-aws/bin/bma rds-db-clusters'
 alias rds-db-instances='~/.bash-my-aws/bin/bma rds-db-instances'
 alias region-each='~/.bash-my-aws/bin/bma region-each'
 alias regions='~/.bash-my-aws/bin/bma regions'
+alias skimstdin='~/.bash-my-aws/bin/bma skimstdin'
 alias stack-arn='~/.bash-my-aws/bin/bma stack-arn'
 alias stack-asg-instances='~/.bash-my-aws/bin/bma stack-asg-instances'
 alias stack-asgs='~/.bash-my-aws/bin/bma stack-asgs'
@@ -160,7 +161,7 @@ alias vpcs='~/.bash-my-aws/bin/bma vpcs'
 # region() needs to be a function in order to let it
 # set AWS_DEFAULT_REGION in the current shell
 function region() { 
-    local inputs=$(__bma_read_inputs $@);
+    local inputs="$@ $(skimstdin)";
     if [[ -z "$inputs" ]]; then
         echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}";
     else

--- a/cloudformation/docker-stack.yml
+++ b/cloudformation/docker-stack.yml
@@ -127,11 +127,7 @@ Resources:
       DesiredCapacity: !Ref 'AsgMinSize'
       Tags:
         - Key: Name
-<<<<<<< HEAD
           Value: !Sub '${AWS::StackName}'
-=======
-          Value: !Sub '${AWS::StackName}/instance'
->>>>>>> Keep docs with code and extract for website.
           PropagateAtLaunch: 'true'
 
   DnsRecord:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -748,7 +748,7 @@ List Launch Configurations
 
 ### launch-configuration-asgs
 
-List EC2 Autoscaling Groups of Launch COnfiguration(s)
+List EC2 Autoscaling Groups of Launch Configuration(s)
 
 
 ### asg-max-size-set
@@ -850,7 +850,7 @@ List images for ECR Repositories
 ### elbs
 
 List ELBs
-Accepts LoadBalancer names or ARNS on STDIN and converts to LoadBalancer names
+Accepts LoadBalancer names on STDIN and converts to LoadBalancer names
 
     $ elbs
     elb-MyLoadBalancer-1FNISWJN0W6N9  2019-12-13T10:24:55.220Z
@@ -915,7 +915,7 @@ List Availability Zones of ELB(s)
 ### elbv2s
 
 List EC2 ELBv2 load balancers (both Network and Application types)
-Accepts Load Balancer names or ARNS on STDIN and converts to Network Load Balancer names
+Accepts Load Balancer names on STDIN and converts to Network Load Balancer names
 
     $ elbv2s
     bash-my-aws      network      internet-facing  active        2020-01-04T11:18:49.733Z
@@ -1001,11 +1001,11 @@ owner defaults to `self` or can one or more of:
 
 image_id can be one or more AMIs
 
-Trialing a different approach for grabbing resource ids from input.  
-As normal, you can pipe resource ids in as first token on each line.  
-We treat all args that don't start with ami- as owner identifiers.  
+Trialing a different approach for grabbing resource ids from input.
+As normal, you can pipe resource ids in as first token on each line.
+We treat all args that don't start with ami- as owner identifiers.
 
-Trialing a new pattern for output - putting the Name at the end.  
+Trialing a new pattern for output - putting the Name at the end.
 This is more like the output of `ls -la`
 
 - Pro: Preceding fields tend to be of the same length
@@ -1039,12 +1039,12 @@ Create SSH Keypair on local machine and import public key into new EC2 Keypair.
 
 Provides benefits over AWS creating the keypair:
 
-Amazon never has access to private key.  
-Private key is protected with passphrase before being written to disk.  
-Keys is written to ~/.ssh with correct file permissions.  
-You control the SSH Key type (algorithm, length, etc).  
+- Amazon never has access to private key.
+- Private key is protected with passphrase before being written to disk.
+- Keys is written to ~/.ssh with correct file permissions.
+- You control the SSH Key type (algorithm, length, etc).
 
-    USAGE: keypair-delete key_name [key_name]
+    USAGE: keypair-create [key_name] [key_dir]
 
     $ keypair-create yet-another-keypair
     Creating /home/m/.ssh/yet-another-keypair
@@ -1413,16 +1413,16 @@ List NTP servers of VPC(s)
 
 ### vpc-endpoints
 
-List VPC Endpoints of VPC(s)
+List VPC Endpoints
 
-    USAGE: vpc-endpoints vpc-id [vpc-id]
+    USAGE: vpc-endpoints [filter]
 
 
 ### vpc-endpoint-services
 
 List available VPC endpoint services
 
-    USAGE: vpc-endpoint-services vpc-id [vpc-id]
+    USAGE: vpc-endpoint-services
 
 
 ### vpc-igw

--- a/functions
+++ b/functions
@@ -113,6 +113,7 @@ rds-db-instances
 region
 region-each
 regions
+skimstdin
 stack-arn
 stack-asg-instances
 stack-asgs

--- a/lib/asg-functions
+++ b/lib/asg-functions
@@ -8,12 +8,12 @@ asgs() {
 
   # List EC2 Autoscaling Groups
 
-  local asg_names=$(__bma_read_inputs)
-  local filters=$(__bma_read_filters "$@")
+  local asg_names=$(skimstdin)
+  local filters=$(__bma_read_filters $@)
 
   # shellcheck disable=SC2086
   aws autoscaling describe-auto-scaling-groups              \
-    ${asg_names:+'--auto-scaling-group-names' $asg_names}   \
+    ${asg_names/#/'--auto-scaling-group-names '}            \
     --output text                                           \
     --query "AutoScalingGroups[].[
       AutoScalingGroupName,
@@ -31,8 +31,8 @@ asg-capacity() {
 
   # List min, desired and maximum capacities of EC2 Autoscaling Group(s)
 
-  local asg_names=$(__bma_read_inputs "$@")
-  [[ -z $asg_names ]] && __bma_usage "auto-scaling-group" && return 1
+  local asg_names="$@ $(skimstdin)"
+  [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
   aws autoscaling describe-auto-scaling-groups \
@@ -47,13 +47,14 @@ asg-capacity() {
   column -s$'\t' -t
 }
 
+
 asg-desired-size-set() {
 
   # Set desired capacity of autoscaling group(s)
 
   local capacity="$1"
   shift
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -71,15 +72,18 @@ asg-instances() {
 
   # List instances of autoscaling group(s)
 
-  local asg_names=$(__bma_read_inputs "$@")
-  [[ -z "$asg_names" ]] && __bma_usage "auto-scaling-group" && return 1
+  local asg_names="$@ $(skimstdin)"
+  [[ -z "$asg_names" ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
   local instance_ids="$(
-    aws autoscaling describe-auto-scaling-groups             \
-      --auto-scaling-group-names $asg_names                  \
-      --query "AutoScalingGroups[].Instances[].[InstanceId]" \
-      --output text
+    aws autoscaling describe-auto-scaling-groups \
+      --auto-scaling-group-names $asg_names      \
+      --output text                              \
+      --query "
+        AutoScalingGroups[].Instances[].[
+          InstanceId
+      ]"
   )"
   if [[ -n "$instance_ids" ]]; then
     echo "$instance_ids" | instances
@@ -91,18 +95,22 @@ asg-launch-configuration() {
 
   # List Launch Configurations of Autoscaling Group(s)
 
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   [[ -z "$asg_names" ]] && __bma_usage "auto-scaling-group" && return 1
 
   # shellcheck disable=SC2086
   local launch_configuration_names="$(
-    aws autoscaling describe-auto-scaling-groups              \
-      --auto-scaling-group-names $asg_names                   \
-      --query "AutoScalingGroups[].[LaunchConfigurationName]" \
-      --output text)"
+    aws autoscaling describe-auto-scaling-groups \
+      --auto-scaling-group-names $asg_names      \
+      --output text                              \
+      --query "
+        AutoScalingGroups[].[
+          LaunchConfigurationName
+        ]"
+  )"
 
   if [[ -n "$launch_configuration_names" ]]; then
-    launch-configurations "$launch_configuration_names"
+    echo "$launch_configuration_names" | launch-configurations
   fi
 }
 
@@ -111,25 +119,27 @@ launch-configurations() {
 
   # List Launch Configurations
 
-  local launch_configuration_names=$(__bma_read_inputs "$@")
+  local launch_configuration_names=$(skimstdin)
+  local filters=$(__bma_read_filters $@)
 
-  aws autoscaling describe-launch-configurations                                              \
-    ${launch_configuration_names:+'--launch-configuration-names' $launch_configuration_names} \
-    --output text                                                                             \
-    --query "LaunchConfigurations[].[
-      LaunchConfigurationName,
-      ImageId,
-      InstanceType
-    ]"              |
+  aws autoscaling describe-launch-configurations                    \
+    ${launch_configuration_names/#/'--launch-configuration-names '} \
+    --output text                                                   \
+    --query "
+      LaunchConfigurations[].[
+        LaunchConfigurationName,
+        ImageId,
+        InstanceType
+    ]" |
   column -s$'\t' -t
 }
 
 
 launch-configuration-asgs() {
 
-  # List EC2 Autoscaling Groups of Launch COnfiguration(s)
+  # List EC2 Autoscaling Groups of Launch Configuration(s)
 
-  local launch_configuration_names=$(__bma_read_inputs "$@")
+  local launch_configuration_names="$@ $(skimstdin)"
   if [[ -z $launch_configuration_names ]] ; then
     __bma_usage "launch_configuration [launch_configuration]"
     return 1
@@ -155,7 +165,7 @@ asg-max-size-set() {
 
   local capacity="$1"
   shift
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -176,7 +186,7 @@ asg-min-size-set() {
 
   local capacity="$1"
   shift
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -196,8 +206,8 @@ asg-processes_suspended() {
   # List suspended processes of an autoscaling group
 
   # TODO: fix the output
-  local asg_names=$(__bma_read_inputs "$@")
-  [[ -z $asg_names ]] && __bma_usage "auto-scaling-group" && return 1
+  local asg_names="$@ $(skimstdin)"
+  [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
   aws autoscaling describe-auto-scaling-groups \
@@ -215,8 +225,8 @@ asg-resume() {
 
   # Resume all processes of an autoscaling group
 
-  local asg_names=$(__bma_read_inputs "$@")
-  [[ -z $asg_names ]] && __bma_usage "auto-scaling-group" && return 1
+  local asg_names="$@ $(skimstdin)"
+  [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name
   for asg_name in $asg_names; do
@@ -229,7 +239,7 @@ asg-suspend() {
 
   # Suspend all processes of an autoscaling group
 
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name
@@ -244,7 +254,7 @@ asg-stack() {
 
   # List CloudFormation stack for asg(s)
 
-  local asg_names=$(__bma_read_inputs "$@")
+  local asg_names="$@ $(skimstdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
@@ -263,8 +273,8 @@ asg-scaling-activities() {
 
   # List scaling activities for Autoscaling Group(s)
 
-  local asg_names=$(__bma_read_inputs "$@")
-  [[ -z $asg_names ]] && __bma_usage "auto-scaling-group" && return 1
+  local asg_names="$@ $(skimstdin)"
+  [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name
   for asg_name in $asg_names; do

--- a/lib/aws-account-functions
+++ b/lib/aws-account-functions
@@ -50,10 +50,10 @@ aws-account-each() {
   #     IAM Role that can assume a Role in each of the specified accounts.
   #     Check the source for more info.
 
-  local aws_account_ids="$(__bma_read_inputs)"
+  local aws_account_ids="$(skimstdin)"
   local cmd=$@
   local assumed_role_name="${AWS_PANOPTICON_ROLE_NAME:-SecurityAuditor}"
-  [[ -z "${aws_account_ids}" ]] && __bma_usage "cmd # pipe in AWS_ACCOUNT_IDS" && return 1
+  [[ -z $aws_account_ids ]] && __bma_usage "cmd # pipe in AWS_ACCOUNT_IDS" && return 1
 
   echo "#command=${cmd}"
   echo "#"
@@ -72,6 +72,7 @@ aws-account-each() {
 
 
 aws-panopticon() {
+
   # aws-panopticon was previous name for aws-account-each()
 
   aws-account-each $@
@@ -86,7 +87,7 @@ aws-account-cost-explorer(){
   #     $ grep demo AWS_ACCOUNTS | aws-account-cost-explorer
   #     #=> Opens web browser to AWS Cost Explorer with accounts selected
 
-  local accounts_formatted="%22$(__bma_read_inputs $@ | sed 's/ /%22,%22/g')%22"
+  local accounts_formatted="%22$(printf "$@ $(skimstdin)" | sed 's/ /%22,%22/g')%22"
 
   local cmd_open="$(hash xdg-open &> /dev/null && echo 'xdg-open' || echo 'open')"
 
@@ -105,7 +106,7 @@ aws-account-cost-recommendations(){
   #     $ grep non_prod AWS_ACCOUNTS | aws-account-each stacks FAILED
   #     #=> Opens web browser to AWS Cost Recommendations with accounts selected
 
-  local accounts_formatted="%22$(__bma_read_inputs | sed 's/ /%22,%22/g')%22"
+  local accounts_formatted="%22$(printf "$@ $(skimstdin)" | sed 's/ /%22,%22/g')%22"
 
   local cmd_open="$(hash xdg-open &> /dev/null && echo 'xdg-open' || echo 'open')"
 

--- a/lib/cert-functions
+++ b/lib/cert-functions
@@ -7,25 +7,35 @@ certs() {
 
   # List ACM Certificates
 
+  local cert_arns=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
   local include_arn_bit=''
   [[ -n ${include_arn:-} ]] && include_arn_bit="CertificateArn,"
-  local cert_arns=$(aws acm list-certificates --output text | cut -f2)
+  local retrieved_cert_arns=$(
+    aws acm list-certificates      \
+      --output text                \
+      --query "
+        CertificateSummaryList[${cert_arns:+?contains(['${cert_arns// /"','"}'], CertificateArn)}].[
+          CertificateArn
+        ]"
+  )
+
   local cert_arn
-  for cert_arn in $cert_arns; do
-    aws acm describe-certificate \
+  for cert_arn in $retrieved_cert_arns; do
+    aws acm describe-certificate    \
       --certificate-arn "$cert_arn" \
-      --query "Certificate.[
-        $include_arn_bit
-        DomainName,
-        Status,
-        length(InUseBy)==\`0\` && 'not-in-use' || 'in-use',
-        NotBefore,
-        NotAfter,
-        join(',', [DomainValidationOptions[].ValidationMethod][])
-      ]" \
-      --output text
+      --output text                 \
+      --query "
+        Certificate.[
+          $include_arn_bit
+          DomainName,
+          Status,
+          length(InUseBy)==\`0\` && 'not-in-use' || 'in-use',
+          NotBefore,
+          NotAfter,
+          join(',', [DomainValidationOptions[].ValidationMethod][])
+      ]"
   done |
   grep -E -- "$filters" |
   LC_ALL=C sort -b -k 5 | # sort by NotAfter
@@ -48,13 +58,13 @@ cert-users() {
   #
   #     USAGE: cert-users cert-arn [cert-arn]
 
-  local cert_arns="$(__bma_read_inputs $@)"
+  local cert_arns="$@ $(skimstdin)"
   [[ -z "$cert_arns" ]] && __bma_usage "cert-arn [cert-arn]" && return 1
 
   local cert_arns
   for cert_arn in $cert_arns; do
     aws acm describe-certificate       \
-      --certificate-arn "${cert_arn}"  \
+      --certificate-arn "$cert_arn"  \
       --output text                    \
       --query "Certificate.InUseBy[].[
         @,
@@ -71,7 +81,7 @@ cert-delete() {
   #
   #     USAGE: cert-delete cert-arn [cert-arn]
 
-  local cert_arns="$(__bma_read_inputs $@)"
+  local cert_arns="$@ $(skimstdin)"
   [[ -z "$cert_arns" ]] && __bma_usage "cert-arn [cert-arn]" && return 1
 
   echo "You are about to delete the following certificates:"

--- a/lib/cloudtrail-functions
+++ b/lib/cloudtrail-functions
@@ -10,20 +10,26 @@ cloudtrails() {
   #     $ cloudtrails
   #     failmode	failmode-cloudtrail	ap-southeast-2	IsMultiRegionTrail=true	IncludeGlobalServiceEvents=true
 
-  local cloudtrails="$(__bma_read_inputs)"
-  local filters=$(__bma_read_filters $@)
+  local cloudtrails="$(skimstdin)"
+  local filters=$(__bma_read_filters "$@")
 
-  aws cloudtrail describe-trails                                                         \
-    $([[ -n ${cloudtrails} ]] && echo --trail-name-list ${cloudtrails})                  \
+  aws cloudtrail describe-trails          \
+    ${cloudtrails/#/'--trail-name-list '} \
+    --output text                         \
     --query "
       trailList[].[
         Name,
         S3BucketName,
         HomeRegion,
-        join('=', ['IsMultiRegionTrail', to_string(IsMultiRegionTrail)]),
-        join('=', ['IncludeGlobalServiceEvents', to_string(IncludeGlobalServiceEvents)])
-      ] "                                                                                \
-    --output text       |
+        join('=', [
+          'IsMultiRegionTrail',
+          to_string(IsMultiRegionTrail)
+        ]),
+        join('=', [
+          'IncludeGlobalServiceEvents',
+          to_string(IncludeGlobalServiceEvents)
+        ])
+      ] "               |
   grep -E -- "$filters"
 
 }
@@ -35,7 +41,7 @@ cloudtrail-status() {
   #
   #     USAGE: cloudtrail-status cloudtrail [cloudtrail]
 
-  local cloudtrails="$(__bma_read_inputs $@)"
+  local cloudtrails="$@ $(skimstdin)"
   [[ -z "$cloudtrails" ]] && __bma_usage "cloudtrail [cloudtrail]" && return 1
 
   local cloudtrail

--- a/lib/ecr-functions
+++ b/lib/ecr-functions
@@ -7,11 +7,11 @@ ecr-repositories() {
 
   # List ECR Repositories
 
-  local aws_account_id=$(__bma_read_inputs)
+  local aws_account_id=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws ecr describe-repositories \
-      $([[ -n ${aws_account_id} ]] && echo --registry-id "${aws_account_id}") \
+  aws ecr describe-repositories          \
+    ${aws_account_id/#/'--registry-id '} \
     --query "
       repositories[].[
         repositoryName,
@@ -33,7 +33,7 @@ ecr-repository-images() {
     local registry_id=${1#registry=}
     shift
   fi
-  local repository_names=$(__bma_read_inputs $@ )
+  local repository_names="$@ $(skimstdin)"
 
   # XXX Display USAGE if no repository_names passed in
 

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -8,18 +8,18 @@
 elbs() {
 
   # List ELBs
-  # Accepts LoadBalancer names or ARNS on STDIN and converts to LoadBalancer names
+  # Accepts LoadBalancer names on STDIN and converts to LoadBalancer names
   #
   #     $ elbs
   #     elb-MyLoadBalancer-1FNISWJN0W6N9  2019-12-13T10:24:55.220Z
   #     another-e-MyLoadBa-171CPCZF2E84T  2019-12-13T10:25:24.300Z
 
-  local elb_names=$(__bma_read_inputs | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws elb describe-load-balancers                                   \
-    $([[ -n $elb_names ]] && echo --load-balancer-names $elb_names) \
-    --output text                                                   \
+  aws elb describe-load-balancers           \
+    ${elb_names/#/'--load-balancer-names '} \
+    --output text                           \
     --query "
       LoadBalancerDescriptions[][
         LoadBalancerName,
@@ -41,12 +41,12 @@ elb-dnsname(){
   #      elb-MyLoadBalancer-1FNISWJN0W6N9  elb-MyLoadBalancer-1FNISWJN0W6N9-563832045.ap-southeast-2.elb.amazonaws.com
   #      another-e-MyLoadBa-171CPCZF2E84T  another-e-MyLoadBa-171CPCZF2E84T-1832721930.ap-southeast-2.elb.amazonaws.com
 
-  local elb_names=$(__bma_read_inputs | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names=$(skimstdin)
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
-  aws elb describe-load-balancers                                   \
-    $([[ -n $elb_names ]] && echo --load-balancer-names $elb_names) \
-    --output text                                                   \
+  aws elb describe-load-balancers           \
+    ${elb_names/#/'--load-balancer-names '} \
+    --output text                           \
     --query "
       LoadBalancerDescriptions[][
         LoadBalancerName,
@@ -62,7 +62,7 @@ elb-instances() {
   #
   #      USAGE: elb-instances load-balancer [load-balancer]
 
-  local elb_names=$(__bma_read_inputs $@)
+  local elb_names="$@ $(skimstdin)"
   [[ -z "${elb_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   local elb_name
@@ -92,7 +92,7 @@ elb-stack() {
   #     elb          elb-MyLoadBalancer-1FNISWJN0W6N9
   #     another-elb  another-e-MyLoadBa-171CPCZF2E84T
 
-  local elb_names=$(__bma_read_inputs $@ | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names="$@ $(skimstdin)"
   [[ -z "$elb_names" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-tags                                            \
@@ -118,7 +118,7 @@ elb-subnets() {
   #     huginn-ELB-BMD0QUX179PK      subnet-5e257318 subnet-7828cd0f subnet-c25fa0a7
   #     prometheus-ELB-C0FGVLGQ64UH  subnet-5e257318 subnet-7828cd0f subnet-c25fa0a7
 
-  local elb_names=$(__bma_read_inputs $@ | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names="$@ $(skimstdin)"
   [[ -z "$elb_names" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-load-balancers    \
@@ -132,6 +132,7 @@ elb-subnets() {
     column -s$'\t' -t
 }
 
+
 elb-azs() {
 
   # List Availability Zones of ELB(s)
@@ -142,7 +143,7 @@ elb-azs() {
   #     rails-demo-ELB-FRBEQPCYSZQD  ap-southeast-2a ap-southeast-2b ap-southeast-2c
   #     huginn-ELB-BMD0QUX179PK      ap-southeast-2a ap-southeast-2b ap-southeast-2c
 
-  local elb_names=$(__bma_read_inputs $@ | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names="$@ $(skimstdin)"
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-load-balancers          \

--- a/lib/elbv2-functions
+++ b/lib/elbv2-functions
@@ -8,18 +8,18 @@
 elbv2s() {
 
   # List EC2 ELBv2 load balancers (both Network and Application types)
-  # Accepts Load Balancer names or ARNS on STDIN and converts to Network Load Balancer names
+  # Accepts Load Balancer names on STDIN and converts to Network Load Balancer names
   #
   #     $ elbv2s
   #     bash-my-aws      network      internet-facing  active        2020-01-04T11:18:49.733Z
   #     bash-my-aws-alb  application  internet-facing  provisioning  2020-01-04T11:29:45.030Z
 
-  local elbv2_names=$(__bma_read_inputs | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\/net\///g' | sed 's/\/.*//g')
+  local elbv2_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws elbv2 describe-load-balancers                         \
-    $([[ -n ${elbv2_names} ]] && echo --names $elbv2_names) \
-    --output text                                           \
+  aws elbv2 describe-load-balancers \
+    ${elbv2_names/#/'--names '}     \
+    --output text                   \
     --query "
       LoadBalancers[][
         LoadBalancerName,
@@ -44,7 +44,7 @@ elbv2-dnsname(){
   #     bash-my-aws      bash-my-aws-c23c598688520e51.elb.ap-southeast-2.amazonaws.com
   #     bash-my-aws-alb  bash-my-aws-alb-2036199590.ap-southeast-2.elb.amazonaws.com
 
-  local elbv2_names=$(__bma_read_inputs | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\/net\///g' | sed 's/\/.*//g')
+  local elbv2_names="$@ $(skimstdin)"
   [[ -z "${elbv2_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \
@@ -69,7 +69,7 @@ elbv2-subnets() {
   #     bash-my-aws      subnet-c25fa0a7
   #     bash-my-aws-alb  subnet-7828cd0f subnet-c25fa0a7
 
-  local elbv2_names=$(__bma_read_inputs | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\/net\///g' | sed 's/\/.*//g')
+  local elbv2_names="$@ $(skimstdin)"
   [[ -z "${elbv2_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \
@@ -94,7 +94,7 @@ elbv2-azs() {
   #     bash-my-aws      ap-southeast-2a
   #     bash-my-aws-alb  ap-southeast-2a ap-southeast-2b
 
-  local elb_names=$(__bma_read_inputs $@ | sed 's/arn[a-zA-Z0-9:\-]*loadbalancer\///g')
+  local elb_names="$@ $(skimstdin)"
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \

--- a/lib/iam-functions
+++ b/lib/iam-functions
@@ -18,16 +18,17 @@ iam-roles() {
   #     AWSBatchServiceRole                      AROAJJWRGUPTRXTV52TED  2017-03-09T05:31:39Z
   #     ecsInstanceRole                          AROAJFQ3WMZXESGIKW5YD  2017-03-09T05:31:39Z
 
+  local role_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
   aws iam list-roles    \
     --output text       \
-    --query '
-      Roles[].[
+    --query "
+      Roles[${role_names:+?contains(['${role_names// /"','"}'], RoleName)}].[
         RoleName,
         RoleId,
         CreateDate
-      ]'                |
+    ]"                  |
   grep -E -- "$filters" |
   LC_ALL=C sort -b -k 3 |
   column -s$'\t' -t
@@ -40,7 +41,7 @@ iam-role-principal(){
   #
   #     USAGE: iam-role-principal role-name [role-name]
 
-  local role_names="$(__bma_read_inputs $@)"
+  local role_names="$@ $(skimstdin)"
   [[ -z "$role_names" ]] && __bma_usage "role-name [role-name]" && return 1
 
   aws iam list-roles                                                         \

--- a/lib/image-functions
+++ b/lib/image-functions
@@ -18,32 +18,33 @@ images() {
   # image_id can be one or more AMIs
 
   #
-  # Trialing a different approach for grabbing resource ids from input.  
-  # As normal, you can pipe resource ids in as first token on each line.  
-  # We treat all args that don't start with ami- as owner identifiers.  
-  local inputs=$(__bma_read_inputs $@)
+  # Trialing a different approach for grabbing resource ids from input.
+  # As normal, you can pipe resource ids in as first token on each line.
+  # We treat all args that don't start with ami- as owner identifiers.
+  local inputs="$@ $(skimstdin)"
   local image_ids=$(echo -n "$inputs" | tr ' ' '\n' | grep ami- | tr '\n' ' ')
   local owners=$(echo -n "$inputs" | tr ' ' '\n' | grep -v ami- | tr '\n' ' ')
 
   #
-  # Trialing a new pattern for output - putting the Name at the end.  
+  # Trialing a new pattern for output - putting the Name at the end.
   # This is more like the output of `ls -la`
   #
   # - Pro: Preceding fields tend to be of the same length
   # - Pro: Easier for eyes to scan final column for names(?)
   # - Con: Using this pattern for instances() would put name past 80 char point
   # - Con: Migrating instances() to this output is A Big Change (not made lightly)
-  aws ec2 describe-images                                            \
-    $([[ -n "$image_ids" ]] && echo --image-ids "${image_ids}")  \
-    $([[ -n "$owners" || -z "$image_ids" ]] && echo --owners "${owners:-self}") \
+
+  aws ec2 describe-images                                                        \
+    $([[ -n "$image_ids" ]] && echo --image-ids "${image_ids}")                  \
+    $([[ -n "$owners" || -z "$image_ids" ]] && echo --owners "${owners:-self}")  \
+    --output text                                                                \
     --query "
       sort_by(Images, &CreationDate)[].[
         ImageId,
         CreationDate,
         OwnerId,
         Name
-      ]"                                                               \
-    --output text |
+      ]"              |
     column -s$'\t' -t
 }
 
@@ -54,7 +55,7 @@ image-deregister() {
   #
   #     USAGE: image-deregister image_id [image_id]
 
-  local image_ids=$(__bma_read_inputs $@)
+  local image_ids="$@ $(skimstdin)"
   [[ -z "${image_ids}" ]] && __bma_usage "image_id" && return 1
 
   local image_id

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -20,11 +20,12 @@ instances() {
   #     i-89cefa9403373d7a5  ami-123456789012  t3.nano  running  postgres1  2019-12-10T08:17:20.000Z  ap-southeast-2a  None
   #     i-806d8f1592e2a2efd  ami-123456789012  t3.nano  running  postgres2  2019-12-10T08:17:22.000Z  ap-southeast-2a  None
 
-  local instance_ids=$(__bma_read_inputs)
+  local instance_ids=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances            \
+    ${instance_ids/#/'--instance-ids '} \
+    --output text                       \
     --query "
       Reservations[].Instances[][
         InstanceId,
@@ -35,8 +36,7 @@ instances() {
         LaunchTime,
         Placement.AvailabilityZone,
         VpcId
-      ]"                                                               \
-    --output text       |
+      ]"                |
   grep -E -- "$filters" |
   LC_ALL=C sort -b -k 6 |
   column -s$'\t' -t
@@ -49,11 +49,12 @@ instance-asg() {
   #
   #     USAGE: instance-asg instance-id [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids=$(skimstdin $@)
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances      \
+    --instance-ids $instance_ids  \
+    --output text                 \
     --query "
       Reservations[].Instances[][
         {
@@ -61,8 +62,7 @@ instance-asg() {
             [Tags[?Key=='aws:autoscaling:groupName'].Value][0][0],
           "InstanceId": InstanceId
         }
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -77,19 +77,19 @@ instance-az() {
   #     i-89cefa9403373d7a5  ap-southeast-2a
   #     i-806d8f1592e2a2efd  ap-southeast-2a
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances      \
+    --instance-ids $instance_ids  \
+    --output text                 \
     --query "
       Reservations[].Instances[][
         [
           InstanceId,
           Placement.AvailabilityZone
         ]
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -113,16 +113,17 @@ instance-console() {
   #     Xen: 0000000000000000 - 000000006a400000 (usable)
   #     ...snip...
 
-  local instance_ids=$(__bma_read_inputs $@)
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
+
   local instance_id
   for instance_id in $instance_ids; do
-    echo Console output for EC2 Instance $instance_id
+    echo
+    echo "Console output for EC2 Instance $instance_id"
     aws ec2 get-console-output     \
       --instance-id "$instance_id" \
-      --query Output               \
-      --output text
-    echo
+      --output text                \
+      --query Output
   done
 }
 
@@ -137,12 +138,12 @@ instance-dns() {
   #     i-89cefa9403373d7a5  ip-10-155-35-61.ap-southeast-2.compute.internal   ec2-54-214-206-114.ap-southeast-2.compute.amazonaws.com
   #     i-806d8f1592e2a2efd  ip-10-178-243-63.ap-southeast-2.compute.internal  ec2-54-214-244-90.ap-southeast-2.compute.amazonaws.com
 
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
-
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances         \
+    --instance-ids $instance_ids     \
+    --output text                    \
     --query "
       Reservations[].Instances[][
         {
@@ -150,8 +151,7 @@ instance-dns() {
           "Private": PrivateDnsName,
           "Public": PublicDnsName
         }
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -162,13 +162,11 @@ instance-health-set-unhealthy() {
   #
   #     USAGE: instance-health-set-unhealthy instance-id [instance-id]
 
-  local instances=$(__bma_read_inputs "$@");
+  local instances="$@ $(skimstdin)";
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
+
   local health_status=Unhealthy
 
-  if [[ -z $instances ]]; then
-      __bma_usage "instance [instance]";
-      return 1;
-  fi;
   local instance;
   for instance in $instances; do
     aws autoscaling set-instance-health \
@@ -184,19 +182,19 @@ instance-iam-profile() {
   #
   #     USAGE: instance-iam-profile instance-id [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instances="$@ $(skimstdin)";
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances      \
+    --instance-ids $instance_ids  \
+    --output text                 \
     --query "
       Reservations[].Instances[][
         [
           InstanceId,
           IamInstanceProfile.Id
         ]
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -211,11 +209,12 @@ instance-ip() {
   #     i-89cefa9403373d7a5  10.155.35.61   54.214.206.114
   #     i-806d8f1592e2a2efd  10.178.243.63  54.214.244.90
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances           \
+    --instance-ids $instance_ids       \
+    --output text                      \
     --query "
       Reservations[].Instances[][
         {
@@ -223,8 +222,7 @@ instance-ip() {
           "Private": PrivateIpAddress,
           "Public": PublicIpAddress
         }
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -235,10 +233,12 @@ instance-ssh() {
   #
   #     USAGE: instance-ssh [login] [instance-id] [instance-id]
 
-  local inputs="$(__bma_read_inputs $@)"
-  local instance_ids=$(echo "$inputs" | tr " " "\n" | grep "^i-" | tr "\n" " ")
-  local user=$(echo "$inputs" | tr " " "\n" | grep -v "^i-" | tr "\n" " ")
-  if [ -z "$instance_ids" ] ; then echo "Usage: $FUNCNAME [login] [instance-id] [instance-id]"; return 1; fi
+  if [[ $1 != *i-* ]]; then
+    local user=${1}
+    shift
+  fi
+  local instance_ids="$@ $(skimstdin)"
+  if [ -z $instance_ids ] ; then echo "Usage: $FUNCNAME [login] [instance-id] [instance-id]"; return 1; fi
 
   exec </dev/tty # reattach keyboard to STDIN
 
@@ -253,14 +253,14 @@ instance-ssh() {
     local USERNAME=${user:-${instance_default_user:-${AWS_DEFAULT_USER:-root}}}
     echo "Connecting to EC2 Instance $instance_id '$instance_name'" 2>&1
 
-    ssh                                  \
-      -t                                \
-      -i ${BMA_SSH_DIR:-~/.ssh/}$keyname \
-      -o LogLevel=error                  \
-      -o StrictHostKeyChecking=no        \
-      -o UserKnownHostsFile=/dev/null    \
-      -l $USERNAME                       \
-      $private_ip
+    ssh                                    \
+      -t                                   \
+      -i "${BMA_SSH_DIR:-~/.ssh/}$keyname" \
+      -o LogLevel=error                    \
+      -o StrictHostKeyChecking=no          \
+      -o UserKnownHostsFile=/dev/null      \
+      -l "$USERNAME"                       \
+      "$private_ip"
   done
 }
 
@@ -271,11 +271,12 @@ instance-ssh-details() {
   #
   #     USAGE: instance-ssh-details [login] [instance-id] [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
+  local instance_ids="$@ $(skimstdin)"
   [[ -z "${instance_ids}" ]] && __bma_usage "instance_id" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances                                      \
+    --instance-ids $instance_ids                                  \
+    --output text                                                 \
     --query "
       Reservations[].Instances[][
         InstanceId,
@@ -283,8 +284,7 @@ instance-ssh-details() {
         (PublicIpAddress || PrivateIpAddress),
         join(' ', [Tags[?Key=='Name'].Value][] || ['not-named']),
         join(' ', [Tags[?Key=='default-user'].Value][] || [''])
-      ]"                                                                \
-    --output text                                                       |
+      ]"            |
   column -s$'\t' -t
 }
 
@@ -299,19 +299,19 @@ instance-stack() {
   #     postgres1  i-89cefa9403373d7a5
   #     postgres2  i-806d8f1592e2a2efd
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances                                         \
+    --instance-ids $instance_ids                                     \
+    --output text                                                    \
     --query "
       Reservations[].Instances[][
         [
           [Tags[?Key=='aws:cloudformation:stack-name'].Value][0][0],
           InstanceId
         ]
-      ][]"                                                                \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -326,8 +326,8 @@ instance-start() {
   #     i-a8b8dd6783e1a40cc  PreviousState=stopped  CurrentState=pending
   #     i-5d74753e210bfe04d  PreviousState=stopped  CurrentState=pending
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 start-instances        \
     --instance-ids $instance_ids \
@@ -352,19 +352,19 @@ instance-state() {
   #     i-89cefa9403373d7a5  running
   #     i-806d8f1592e2a2efd  running
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances        \
+    --instance-ids $instance_ids    \
+    --output text                   \
     --query "
       Reservations[].Instances[][
         {
           "InstanceId": InstanceId,
           "State": State.Name
         }
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 
@@ -380,8 +380,8 @@ instance-stop() {
   #     i-a8b8dd6783e1a40cc  PreviousState=running  CurrentState=stopping
   #     i-5d74753e210bfe04d  PreviousState=running  CurrentState=stopping
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 stop-instances         \
     --instance-ids $instance_ids \
@@ -402,17 +402,17 @@ instance-tags() {
   #
   #     USAGE: instance-tags instance-id [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances                            \
+    --instance-ids $instance_ids                        \
+    --output text                                       \
     --query "
       Reservations[].Instances[].[
         InstanceId,
         join(' ', [Tags[].[join('=',[Key,Value])][]][])
-      ]"                                                                \
-    --output text                                                       |
+      ]"            |
   column -s$'\t' -t
 }
 
@@ -432,11 +432,11 @@ instance-terminate() {
   #     i-01c7edb986c18c16a  PreviousState=terminated  CurrentState=terminated
   #     i-012dded46894dfa04  PreviousState=running     CurrentState=shutting-down
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to terminate the following instances:"
-  instances "$instance_ids"
+  echo "$instance_ids" | instances
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r
@@ -469,8 +469,8 @@ instance-termination-protection() {
   #     i-806d8f1592e2a2efd DisableApiTermination=false
   #     i-61e86ac6be1e2c193 DisableApiTermination=false
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   for instance_id in $instance_ids; do
     aws ec2 describe-instance-attribute \
@@ -494,11 +494,11 @@ instance-termination-protection-disable() {
   #
   #     USAGE: instance-termination-protection-disable instance-id [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to disable termination protection on the following instances:"
-  instances "$instance_ids"
+  echo "$instance_ids" | instances
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r
@@ -509,7 +509,7 @@ instance-termination-protection-disable() {
       aws ec2 modify-instance-attribute   \
         --attribute disableApiTermination \
         --value false                     \
-        --instance-id $instance_id
+        --instance-id "$instance_id"
     done
   fi
 }
@@ -521,8 +521,8 @@ instance-termination-protection-enable() {
   #
   #     USAGE: instance-termination-protection-enable instance-id [instance-id]
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to enable termination protection on the following instances:"
   instances "$instance_ids"
@@ -536,7 +536,7 @@ instance-termination-protection-enable() {
       aws ec2 modify-instance-attribute   \
         --attribute disableApiTermination \
         --value true                      \
-        --instance-id $instance_id
+        --instance-id "$instance_id"
     done
   fi
 }
@@ -554,11 +554,11 @@ instance-type() {
   #     i-806d8f1592e2a2efd  t3.nano
   #     i-61e86ac6be1e2c193  t3.nano
 
-  local instance_ids="$(__bma_read_inputs $@)"
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+    $([[ -n $instance_ids ]] && echo --instance-ids ${instance_ids})  \
     --query "
       Reservations[].Instances[][
         [
@@ -577,17 +577,17 @@ instance-userdata() {
   #
   #     USAGE: instance-userdata instance-id [instance-id]
 
-  local instance_ids=$(__bma_read_inputs $@)
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
   local instance_id
   for instance_id in $instance_ids; do
     echo Userdata for EC2 Instance $instance_id
     aws ec2 describe-instance-attribute \
       --attribute userData              \
-      --instance-id $instance_id        \
+      --instance-id "$instance_id"      \
       --query UserData                  \
-      --output text                     |
-        base64 --decode
+      --output text    |
+    base64 --decode
     echo
   done
 }
@@ -603,11 +603,11 @@ instance-volumes() {
   #     i-89cefa9403373d7a5  vol-cf5ddae9
   #     i-806d8f1592e2a2efd  vol-38fd45c3
 
-  local instance_ids=$(__bma_read_inputs $@)
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+    $([[ -n $instance_ids ]] && echo --instance-ids ${instance_ids})  \
     --query "
       Reservations[].Instances[][
         [
@@ -626,19 +626,19 @@ instance-vpc() {
   #
   #     USAGE: instance-vpcs instance-id [instance-id]
 
-  local instance_ids=$(__bma_read_inputs $@)
-  [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
+  local instance_ids="$@ $(skimstdin)"
+  [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 describe-instances                                            \
-    $([[ -n ${instance_ids} ]] && echo --instance-ids ${instance_ids})  \
+  aws ec2 describe-instances     \
+    --instance-ids $instance_ids \
+    --output text                \
     --query "
       Reservations[].Instances[][
         [
           VpcId,
           InstanceId
         ]
-      ][]"                                                              \
-    --output text                                                       |
+      ][]"          |
   column -s$'\t' -t
 }
 

--- a/lib/keypair-functions
+++ b/lib/keypair-functions
@@ -13,12 +13,12 @@ keypairs() {
   #     alice  8f:85:9a:1e:6c:76:29:34:37:45:de:7f:8d:f9:70:eb
   #     bob    56:73:29:c2:ad:7b:6f:b6:f2:f3:b4:de:e4:2b:12:d4
 
-  local keypairs=$(__bma_read_inputs)
+  local keypairs="$(skimstdin)"
   local filters=$(__bma_read_filters $@)
 
-  aws ec2 describe-key-pairs                                \
-    $([[ -n ${keypairs} ]] && echo --key-names ${keypairs}) \
-    --query 'KeyPairs[].[KeyName, KeyFingerprint]'          \
+  aws ec2 describe-key-pairs                       \
+    ${keypairs/#/'--key-names '}                   \
+    --query 'KeyPairs[].[KeyName, KeyFingerprint]' \
     --output text       |
   grep -E -- "$filters" |
   column -s$'\t' -t
@@ -31,12 +31,12 @@ keypair-create() {
   #
   # Provides benefits over AWS creating the keypair:
   #
-  # Amazon never has access to private key.  
-  # Private key is protected with passphrase before being written to disk.  
-  # Keys is written to ~/.ssh with correct file permissions.  
-  # You control the SSH Key type (algorithm, length, etc).  
+  # - Amazon never has access to private key.
+  # - Private key is protected with passphrase before being written to disk.
+  # - Keys is written to ~/.ssh with correct file permissions.
+  # - You control the SSH Key type (algorithm, length, etc).
   #
-  #     USAGE: keypair-delete key_name [key_name]
+  #     USAGE: keypair-create [key_name] [key_dir]
   #
   #     $ keypair-create yet-another-keypair
   #     Creating /home/m/.ssh/yet-another-keypair
@@ -101,17 +101,18 @@ keypair-delete() {
   #     yet-another-keypair
   #     Are you sure you want to continue? y
 
-  local keypairs=$(__bma_read_inputs $@)
-  local keypair
-  [[ -z ${keypairs} ]] && __bma_usage "key_name [key_name]" && return 1
+  local keypairs="$@ $(skimstdin)"
+  [[ -z $keypairs ]] && __bma_usage "key_name [key_name]" && return 1
+
   echo "You are about to delete the following EC2 SSH KeyPairs:"
-  echo "$keypairs" | tr ' ' "\n"
+  echo "$keypairs" | keypairs
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then
+    local keypair
     for keypair in $keypairs; do
       aws ec2 delete-key-pair --key-name "$keypair"
     done

--- a/lib/kms-functions
+++ b/lib/kms-functions
@@ -71,16 +71,17 @@ kms-aliases() {
   #     $ kms-aliases default
   #     alias/default  d714a175-db12-4574-8f27-aa071a1dfd8a  arn:aws:kms:ap-southeast-2:089834043791:alias/default
 
+  # TODO Accept alias_names from STDIN and filter in query
   local filters=$(__bma_read_filters $@)
 
-  aws kms list-aliases                           \
+  aws kms list-aliases  \
+    --output text       \
     --query "
       Aliases[].[
         AliasName,
         TargetKeyId,
         AliasArn
-      ]"                                      \
-    --output text       |
+      ]"                |
   grep -E -- "$filters" |
   column -s$'\t' -t
 }
@@ -101,10 +102,8 @@ kms-alias-create() {
   #     alias/foobar  d714a175-db12-4574-8f27-aa071a1dfd8a  arn:aws:kms:ap-southeast-2:089834043791:alias/foobar
 
   local alias_name="$1"
-  [[ -z "$alias_name" ]] && __bma_usage "alias_name key_id" && return 1
-  shift
-  local key_id=$(__bma_read_inputs "$@" | cut -f 1)
-  [[ -z "$alias_name" ]] && __bma_usage "alias_name key_id" && return 1
+  local key_id="$2"
+  [[ -z "$alias_name" || -z "$key_id" ]] && __bma_usage "alias_name key_id" && return 1
 
  # prepend "alias/" to alias_name if missing
   aws kms create-alias         \
@@ -124,7 +123,7 @@ kms-alias-delete() {
   #     alias/foobar
   #     Are you sure you want to continue? y
 
-  local alias_names="$(__bma_read_inputs $@)"
+  local alias_names="$@ $(skimstdin)"
   [[ -z "$alias_names" ]] && __bma_usage "alias_name [alias_name]" && return 1
 
    echo "You are about to delete the following kms aliases:"
@@ -183,7 +182,7 @@ kms-key-details() {
 
   # List details for KMS Key(s)
 
-  local key_ids="$(__bma_read_inputs $@)"
+  local key_ids="$@ $(skimstdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids
@@ -213,7 +212,7 @@ kms-key-disable() {
   #
   #     $ kms-key-disable  9e94333b-8e85-497a-9791-e7c5edf9c35e
 
-  local key_ids="$(__bma_read_inputs $@)"
+  local key_ids="$@ $(skimstdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids
@@ -231,7 +230,7 @@ kms-key-enable() {
   #
   #     $ kms-key-enable  9e94333b-8e85-497a-9791-e7c5edf9c35e
 
-  local key_ids="$(__bma_read_inputs $@)"
+  local key_ids="$@ $(skimstdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids

--- a/lib/lambda-functions
+++ b/lib/lambda-functions
@@ -11,6 +11,7 @@ lambda-functions() {
   #     stars    2019-12-18T10:00:00.000+0000  python2.7  256
   #     stripes  2019-12-19T10:21:42.444+0000  python3.7  128
 
+  local function_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
   local column_command
@@ -23,7 +24,7 @@ lambda-functions() {
   aws lambda list-functions \
     --output text           \
     --query "
-      Functions[].[
+      Functions[${function_names:+?contains(['${function_names// /"','"}'], FunctionName)}].[
         FunctionName,
         LastModified,
         Runtime,
@@ -42,7 +43,7 @@ lambda-function-memory(){
   #
   #     USAGE: lambda-function-memory function [function]
 
-  local function_names="$(__bma_read_inputs $@)"
+  local function_names="$@ $(skimstdin)"
   [[ -z "$function_names" ]] && __bma_usage "function [function]" && return 1
 
   local column_command
@@ -74,7 +75,7 @@ lambda-function-memory-set(){
   local usage_msg="memory function [function]"
   [[ -z "${memory}" ]] && __bma_usage "$usage_msg" && return 1
 
-  local function_names=$(__bma_read_inputs $@)
+  local function_names="$@ $(skimstdin)"
   [[ -z "${function_names}" && -t 0 ]] && __bma_usage "$usage_msg" && return 1
 
   local function_name
@@ -107,11 +108,11 @@ lambda-function-memory-step(){
   [[ -z "${memory_last}" ]] && __bma_usage $usage_msg && return 1
   # XXX check it's a valid memory size
 
-  local function_names=$(__bma_read_inputs $@)
+  local function_names="$@ $(skimstdin)"
   [[ -z "${function_names}" && -t 0 ]] && __bma_usage $usage_msg && return 1
 
   echo "You are about to step memory for following functions:"
-  echo $function_names | tr ' ' "\n"
+  echo $function_names | lambda-functions
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r

--- a/lib/log-functions
+++ b/lib/log-functions
@@ -13,6 +13,7 @@ log-groups() {
   #     /aws/lambda/stars   1576566745961  0  107460
   #     /aws/lambda/walk    1576567300172  0   11794
 
+  local log_group_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
   local column_command
@@ -23,12 +24,14 @@ log-groups() {
   fi
 
   aws logs describe-log-groups    \
-    --query 'logGroups[].[
-               logGroupName,
-               creationTime,
-               metricFilterCount,
-               storedBytes]'      \
-    --output text |
+    --output text                 \
+    --query "
+      logGroups[${log_group_names:+?contains(['${log_group_names// /"','"}'], logGroupName)}].[
+        logGroupName,
+        creationTime,
+        metricFilterCount,
+        storedBytes
+      ]"                |
   grep -E -- "$filters" |
   LC_ALL=C sort --key 2 |
   $column_command

--- a/lib/misc-functions
+++ b/lib/misc-functions
@@ -2,15 +2,16 @@
 #
 # miscellaneous functions that don't belong anywhere else
 
-# columnise(): Handy function to columnise output
-#
-# Leaving the command itself in functions (for now) to be explicit but
-# I'm finding it handy to have this function at the CLI for formatting
-# output from commands run in a loop.
-#
-# Looped commands (such as those with multiple resources piped in) do
-# not delay output by sending the aggregate through `column`.
-#
 columnise() {
+
+  # Handy function to columnise output
+  #
+  # Leaving the command itself in functions (for now) to be explicit but
+  # I'm finding it handy to have this function at the CLI for formatting
+  # output from commands run in a loop.
+  #
+  # Looped commands (such as those with multiple resources piped in) do
+  # not delay output by sending the aggregate through `column`.
+
   column -s$'\t' -t
 }

--- a/lib/region-functions
+++ b/lib/region-functions
@@ -40,7 +40,7 @@ region() {
   #     $ region
   #     ap-southeast-2
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   if [[ -z "$inputs" ]]; then
     echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
   else

--- a/lib/route53-functions
+++ b/lib/route53-functions
@@ -12,20 +12,23 @@ hosted-zones(){
   #     /hostedzone/Z1111111111111  3   NotPrivateZone  bash-my-aws.com.
   #     /hostedzone/Z2222222222222  3   NotPrivateZone  bashmyaws.com.
 
+  local ids=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws route53 list-hosted-zones     \
-    --query "HostedZones[].[
-               Id,
-               ResourceRecordSetCount,
-               (Config.PrivateZone && 'PrivateZone') || 'NotPrivateZone',
-               Name
-             ]" \
-    --output text       |
+  aws route53 list-hosted-zones \
+    --output text               \
+    --query "
+      HostedZones[${ids:+?contains(['${ids// /"','"}'], Id)}].[
+        Id,
+        ResourceRecordSetCount,
+        (Config.PrivateZone && 'PrivateZone') || 'NotPrivateZone',
+        Name
+      ]"                |
   sort -k 4             |
   grep -E -- "$filters" |
   column -s$'\t' -t
 }
+
 
 hosted-zone-ns-records(){
 
@@ -40,7 +43,8 @@ hosted-zone-ns-records(){
   #     bash-my-aws.org. 300 IN NS	ns-362.awsdns-45.com.
   #     bash-my-aws.org. 300 IN NS	ns-1464.awsdns-55.org.
 
-  local hosted_zone_id="$(__bma_read_inputs $@)"
+  local inputs="$@ $(skimstdin)"
+  local hosted_zone_id=$(echo "$inputs" | awk '{print $1}')
   [[ -z "$hosted_zone_id" ]] && __bma_usage "hosted-zone-id" && return 1
 
   local hosted_zone_name
@@ -51,12 +55,12 @@ hosted-zone-ns-records(){
       --output text
   )
 
-  aws route53 list-resource-record-sets                    \
-    --hosted-zone-id $hosted_zone_id                       \
+  aws route53 list-resource-record-sets                   \
+    --hosted-zone-id "$hosted_zone_id"                    \
+    --output text                                         \
     --query "
       ResourceRecordSets[?Type=='NS'].ResourceRecords[].[
         '$hosted_zone_name 300 IN NS',
         Value
-      ]"                                                   \
-  --output text
+      ]"
 }

--- a/lib/s3-functions
+++ b/lib/s3-functions
@@ -12,11 +12,16 @@ buckets() {
   #     backups     2019-12-20  08:24:44.351215
   #     archive     2019-12-20  08:24:57.567652
 
+  local bucket_names=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
   aws s3api list-buckets \
-    --query "Buckets[].[Name, CreationDate]" \
-    --output text       |
+    --output text        \
+    --query "
+      Buckets[${bucket_names:+?contains(['${bucket_names// /"','"}'], Name)}].[
+        Name,
+        CreationDate
+      ]"                |
   grep -E -- "$filters" |
   column -t
 }
@@ -34,19 +39,19 @@ bucket-acls() {
   #     permission to the Amazon S3 Log Delivery group to write access log
   #     objects to your bucket. [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-alternatives-guidelines.html)
 
-  local buckets=$(__bma_read_inputs $@)
+  local buckets="$@ $(skimstdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   local bucket
   for bucket in $buckets; do
     aws s3api get-bucket-acl \
       --bucket "$bucket"     \
+      --output text          \
       --query "[
-         '$bucket', 
-         join(' ', Grants[?Grantee.Type=='Group'].[join('=',[Permission, Grantee.URI])][])
-      ]" \
-      --output text |
-      sed 's#http://acs.amazonaws.com/groups/##g' 
+        '$bucket',
+        join(' ', Grants[?Grantee.Type=='Group'].[join('=',[Permission, Grantee.URI])][])
+      ]" |
+    sed 's#http://acs.amazonaws.com/groups/##g'
   done
 }
 
@@ -63,11 +68,11 @@ bucket-remove() {
   #     Are you sure you want to continue? y
   #     remove_bucket failed: s3://another-example-bucket An error occurred (BucketNotEmpty) when calling the DeleteBucket operation: The bucket you tried to delete is not empty
 
-  local buckets=$(__bma_read_inputs $@)
+  local buckets="$@ $(skimstdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   echo "You are about to remove the following buckets:"
-  buckets "$buckets"
+  echo "$buckets" | buckets
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r
@@ -93,11 +98,11 @@ bucket-remove-force() {
   #     delete: s3://another-example-bucket/aliases
   #     remove_bucket: another-example-bucket
 
-  local buckets=$(__bma_read_inputs $@)
+  local buckets="$@ $(skimstdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   echo "You are about to delete all objects from and remove the following buckets:"
-  buckets "$buckets"
+  echo "$buckets" | buckets
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
   local regex_yes="^[Yy]$"
   read -p "Are you sure you want to continue? " -n 1 -r

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -5,17 +5,11 @@
 # Used by bash-my-aws functions to work with stdin and arguments.
 
 __bma_read_inputs() {
-  echo $(__bma_read_stdin) $@ |
-    sed -E 's/\ +$//'         |
-    sed -E 's/^\ +//'
+  echo $(__bma_read_stdin) $@
 }
 
 __bma_read_stdin() {
-  [[ -t 0 ]] ||
-    cat                  |
-      awk '{ print $1 }' |
-      tr '\n' ' '        |
-      sed 's/\ $//'
+  [[ -t 0 ]] || awk 'ORS=" " { print $1 }'
 }
 
 # Construct a string to be passed to `grep -E`

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -4,25 +4,45 @@
 #
 # Used by bash-my-aws functions to work with stdin and arguments.
 
-__bma_read_inputs() {
-  echo $(__bma_read_stdin) $@
-}
 
-__bma_read_stdin() {
+skimstdin() {
+  # Return the first token from each line of STDIN
   [[ -t 0 ]] || awk 'ORS=" " { print $1 }'
 }
 
-# Construct a string to be passed to `grep -E`
-__bma_read_filters() {
-  local IFS_SAVED="$IFS"; IFS=$'|'
-  printf -- "$*"
-  IFS=$IFS_SAVED
+
+__bma_read_inputs() {
+  # deprecated
+  echo $(skimstdin) $@
 }
+
+
+__bma_read_stdin() {
+  # deprecated - use skimstdin
+  [[ -t 0 ]] ||
+    cat                  |
+      awk '{ print $1 }' |
+      tr '\n' ' '        |
+      sed 's/\ $//'
+}
+
+
+__bma_read_filters() {
+
+  # Construct a string to be passed to `grep -E`
+  #
+  #     $ __bma_read_filters foo bar baz
+  #     foo|bar|baz
+
+  ( IFS=$'|'; printf -- "$*" )
+}
+
 
 __bma_error() {
   echo "ERROR: $@" > /dev/stderr
   return 1
 }
+
 
 __bma_usage() {
   echo "USAGE: ${FUNCNAME[1]} $@" > /dev/stderr

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -53,8 +53,8 @@ stacks() {
   #     postgres1  CREATE_COMPLETE  2019-04-14T15:22:44Z  NEVER_UPDATED  NOT_NESTED
   #     postgres2  CREATE_COMPLETE  2019-05-18T05:45:50Z  NEVER_UPDATED  NOT_NESTED
 
+  local stack_names=$(skimstdin) # Filter by stack-names from STDIN (optional)
   local filters=$(__bma_read_filters $@) # Filter output by arguments (optional)
-  local stack_names=$(__bma_read_inputs) # Filter by stack-names from STDIN (optional)
 
   aws cloudformation list-stacks                      \
     --stack-status                                    \
@@ -104,7 +104,7 @@ stack-arn() {
   #     arn:aws:cloudformation:us-east-1:000000000000:stack/postgres2/7420bbd4-3026-444f-b55b-fa0a9d564730
   #     arn:aws:cloudformation:us-east-1:000000000000:stack/prometheus-web/805e081c-b8eb-4f6c-9872-2b5cddc77fba
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   local stack
   for stack in $stacks; do
@@ -120,10 +120,10 @@ stack-cancel-update() {
 
   # Cancel an in-progress stack update
 
-  local stack=$(_bma_stack_name_arg $(__bma_read_inputs $@))
+  local stack=$(_bma_stack_name_arg "$@ $(skimstdin)")
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
-  aws cloudformation cancel-update-stack --stack-name $stack
+  aws cloudformation cancel-update-stack --stack-name "$stack"
 }
 
 
@@ -299,7 +299,7 @@ stack-delete() {
 
   # *Note that the error reported at the end of `stack-delete` command is just AWSCLI saying it can't find the stack anymore.*
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   local stack
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   if ! [ -t 0 ] ; then # if STDIN is not a terminal...
@@ -332,7 +332,7 @@ stack-exports() {
 }
 
 stack-recreate() {
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z "${stack}" ]] && __bma_usage "stack" && return 1
 
@@ -357,7 +357,7 @@ stack-failure() {
 
   # Return reason a stack failed to update/create/delete
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z "${stack}" ]] && __bma_usage "stack" && return 1
 
@@ -379,7 +379,7 @@ stack-events() {
   #
   #     USAGE: stack-events stack
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -415,7 +415,7 @@ stack-resources() {
   #     i-2aa95cc214a461398  AWS::EC2::Instance  prometheus-web
 
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local stack
@@ -445,7 +445,7 @@ stack-asgs() {
   #     asg-bash-my-aws-AutoScalingGroup-MSBCWRTI3PVM  AWS::AutoScaling::AutoScalingGroup  asg-bash-my-aws
   #     asg2-AutoScalingGroup-1FHUVUJ7SLPU7            AWS::AutoScaling::AutoScalingGroup  asg2
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   stack-resources $stacks                 |
@@ -464,7 +464,7 @@ stack-asg-instances() {
   #     i-06ee900565652ecc5  ami-0119aa4d67e59007c  t3.nano  running  asg-bash-my-aws  2019-12-13T03:15:22.000Z  ap-southeast-2c  vpc-deb8edb9
   #     i-01c7edb986c18c16a  ami-0119aa4d67e59007c  t3.nano  running  asg2             2019-12-13T03:37:51.000Z  ap-southeast-2c  vpc-deb8edb9
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local asgs=$(stack-asgs $stacks)
@@ -484,7 +484,7 @@ stack-elbs() {
   #     elb-MyLoadBalancer-NA5S72MLA5KI   AWS::ElasticLoadBalancing::LoadBalancer  elb-stack-1
   #     load-bala-MyLoadBa-11HZ0DHUHJZZI  AWS::ElasticLoadBalancing::LoadBalancer  elb-stack-2
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   stack-resources $stacks                      |
@@ -506,7 +506,7 @@ stack-instances() {
   #     i-5d74753e210bfe04d  ami-123456789012  t3.nano  running  postgres2       2019-12-13T02:24:34.000Z  ap-southeast-2a  None
   #     i-2aa95cc214a461398  ami-123456789012  t3.nano  running  prometheus-web  2019-12-13T02:24:36.000Z  ap-southeast-2a  None
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local instance_ids=$(stack-resources $stacks | grep AWS::EC2::Instance | awk '{ print $1 }')
@@ -516,7 +516,7 @@ stack-instances() {
 
 stack-parameters() {
   # List parameters of stack
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -531,7 +531,7 @@ stack-status() {
 
   # List status of stack
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local stack
@@ -551,7 +551,7 @@ stack-tag() {
   local tag=$1
   shift 1
   [[ -z "${tag}" ]] && __bma_usage "tag-key stack [stack]" && return 1
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
   [[ -z ${stacks} && -t 0 ]] && __bma_usage "tag-key stack [stack]" && return 1
   local stack
   for stack in $stacks; do
@@ -579,7 +579,7 @@ stack-tag() {
 # XXX   [[ -z "${tag_key}" ]]    && __bma_usage $usage_msg && return 1
 # XXX   [[ -z "${tag_value}" ]] && __bma_usage $usage_msg && return 1
 # XXX 
-# XXX   local stacks=$(__bma_read_inputs $@)
+# XXX   local stacks="$@ $(skimstdin)"
 # XXX   [[ -z "${stacks}" && -t 0 ]] && __bma_usage $usage_msg && return 1
 # XXX 
 # XXX   local stack
@@ -627,7 +627,7 @@ stack-tag() {
 # XXX   shift 1
 # XXX   [[ -z "${tag_key}" ]] && __bma_usage "tag-key stack [stack]" && return 1
 # XXX 
-# XXX   local stacks=$(__bma_read_inputs $@)
+# XXX   local stacks="$@ $(skimstdin)"
 # XXX   [[ -z "${stacks}" ]] && __bma_usage "tag-key stack [stack]" && return 1
 # XXX 
 # XXX   local stack
@@ -662,7 +662,7 @@ stack-tail() {
 
   # Show all events for CF stack until update completes or fails.
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -696,7 +696,7 @@ stack-template() {
 
   # Return template of a stack
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
 
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
@@ -712,7 +712,7 @@ stack-tags() {
 
   # List stack-tags applied to a stack
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
 
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
@@ -729,7 +729,7 @@ stack-tags-text() {
 
   # List stack-tags applied to a stack on a single line
 
-  local stacks=$(__bma_read_inputs $@)
+  local stacks="$@ $(skimstdin)"
 
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   local stack
@@ -749,7 +749,7 @@ stack-outputs() {
 
   # List outputs of a stack
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -770,7 +770,7 @@ stack-validate() {
 
   # Validate a stack template
 
-  local inputs=$(__bma_read_inputs $@ | cut -f1)
+  local inputs=$(printf "$@ $(skimstdin)" | cut -f1)
   [[ -z "$inputs" ]] && __bma_usage "template-file" && return 1
   size=$(wc -c <"$inputs")
   if [[ $size -gt 51200 ]]; then
@@ -778,7 +778,7 @@ stack-validate() {
     __bma_error "template too large: $size bytes, 51200 max"
     return 1
   else
-    aws cloudformation validate-template --template-body file://$inputs
+    aws cloudformation validate-template --template-body "file://$inputs"
   fi
 }
 
@@ -811,7 +811,7 @@ stack-diff(){
   #        {
   #          "ParameterKey": "InstanceType",
 
-  local inputs=$(__bma_read_inputs $@)
+  local inputs="$@ $(skimstdin)"
   [[ -z "$inputs" ]] && __bma_usage "stack [template-file]" && return 1
   _bma_stack_diff_template $inputs
   [[ $? -ne 0 ]] && __bma_usage "stack [template-file]" && return 1
@@ -829,7 +829,7 @@ _bma_stack_diff_template() {
   _bma_stack_args $@
   [[ $? -ne 0 ]] && return 1
 
-  if ! aws cloudformation describe-stacks --stack-name $stack 1>/dev/null; then
+  if ! aws cloudformation describe-stacks --stack-name "$stack" 1>/dev/null; then
     return 1;
   fi
   if [ "x$( type -P colordiff )" != "x" ]; then

--- a/lib/vpc-functions
+++ b/lib/vpc-functions
@@ -41,12 +41,12 @@ subnets(){
   #     subnet-8bb774fe  vpc-018d9739  ap-southeast-2a  172.31.0.0/20   NO_NAME
   #     subnet-9eea2c07  vpc-018d9739  ap-southeast-2b  172.31.16.0/20  NO_NAME
 
+  local subnet_ids=$(skimstdin)
   local filters=$(__bma_read_filters $@)
-  local subnet_ids=$(__bma_read_inputs)
 
-  aws ec2 describe-subnets                                       \
-    $([[ -n ${subnet_ids} ]] && echo --subnet-ids ${subnet_ids}) \
-    --output text                                                \
+  aws ec2 describe-subnets          \
+    ${subnet_ids/#/'--subnet-ids '} \
+    --output text                   \
     --query "Subnets[].[
       SubnetId,
       VpcId,
@@ -67,20 +67,21 @@ vpcs() {
   #     $ vpcs
   #     vpc-018d9739  default-vpc  NO_NAME  172.31.0.0/16  NO_STACK  NO_VERSION
 
-  local vpc_ids="$(__bma_read_inputs)"
+  local vpc_ids=$(skimstdin)
   local filters=$(__bma_read_filters $@)
 
-  aws ec2 describe-vpcs                                                 \
-    $([[ -n ${vpc_ids} ]] && echo --vpc-ids ${vpc_ids})                 \
-    --output text                                                       \
-    --query 'Vpcs[].[
-      VpcId,
-      ((IsDefault==`false`)&&`not-default`)||`default-vpc`,
-      join(`,`, [Tags[?Key==`Name`].Value || `NO_NAME`][]),
-      CidrBlock,
-      join(`,`, [Tags[?Key==`aws:cloudformation:stack-name`].Value || `NO_STACK`][]),
-      join(`,`, [Tags[?Key==`version`].Value || `NO_VERSION`][])
-    ]'                  |
+  aws ec2 describe-vpcs       \
+    ${vpc_ids/#/'--vpc-ids '} \
+    --output text             \
+    --query '
+      Vpcs[].[
+        VpcId,
+        ((IsDefault==`false`)&&`not-default`)||`default-vpc`,
+        join(`,`, [Tags[?Key==`Name`].Value || `NO_NAME`][]),
+        CidrBlock,
+        join(`,`, [Tags[?Key==`aws:cloudformation:stack-name`].Value || `NO_STACK`][]),
+        join(`,`, [Tags[?Key==`version`].Value || `NO_VERSION`][])
+      ]'                |
   grep -E -- "$filters" |
   column -s$'\t' -t
 }
@@ -95,13 +96,13 @@ vpc-azs() {
   #     $ vpcs | vpc-azs
   #     vpc-018d9739 ap-southeast-2a ap-southeast-2b ap-southeast-2c
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
   for vpc_id in $vpc_ids; do
     echo -n "$vpc_id "
-    echo "$vpc_id" | vpc-subnets | awk '{print $3}' | LC_ALL=C sort -u | tr "\n" ' '
+    echo "$vpc_id" | vpc-subnets LC_ALL=C sort -u | awk 'ORS=" " {print $3}'
     echo
   done
 }
@@ -116,7 +117,7 @@ vpc-az-count() {
   #     $ vpcs | vpc-az-count
   #     vpc-018d9739 3
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -132,7 +133,7 @@ vpc-lambda-functions(){
   #
   #     USAGE: vpc-lambda-functions vpc-id [vpc-id]
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -163,23 +164,24 @@ vpc-dhcp-options-ntp(){
 
 vpc-endpoints(){
 
-  # List VPC Endpoints of VPC(s)
+  # List VPC Endpoints
   #
-  #     USAGE: vpc-endpoints vpc-id [vpc-id]
+  #     USAGE: vpc-endpoints [filter]
 
-  local vpc_ids="$(__bma_read_inputs)"
+  local vpc_endpoint_ids=$(skimstdin)
   local filters=$(__bma_read_filters $@ $vpc_ids)
 
-  aws ec2 describe-vpc-endpoints \
-  --output text                  \
-  --query '
-    VpcEndpoints[].[
-      VpcEndpointId,
-      VpcId,
-      State,
-      VpcEndpointType,
-      ServiceName
-    ]'                  |
+  aws ec2 describe-vpc-endpoints                \
+    ${vpc_endpoint_ids/#/'--vpc-endpoint-ids '} \
+    --output text                               \
+    --query '
+      VpcEndpoints[].[
+        VpcEndpointId,
+        VpcId,
+        State,
+        VpcEndpointType,
+        ServiceName
+      ]'                |
   grep -E -- "$filters" |
   sort -k 5             |
   column -s$'\t' -t
@@ -190,7 +192,7 @@ vpc-endpoint-services(){
 
   # List available VPC endpoint services
   #
-  #     USAGE: vpc-endpoint-services vpc-id [vpc-id]
+  #     USAGE: vpc-endpoint-services
 
   local filters=$(__bma_read_filters $@)
 
@@ -213,16 +215,17 @@ vpc-igw() {
   #
   #     USAGE: vpc-igw vpc-id [vpc-id]
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
   for vpc_id in $vpc_ids; do
     aws ec2 describe-internet-gateways                                       \
       --output text                                                          \
-      --query "InternetGateways[?contains(Attachments[].VpcId, '$vpc_id')].[
-        InternetGatewayId,
-        join(',', Attachments[].VpcId)
+      --query "
+        InternetGateways[?contains(Attachments[].VpcId, '$vpc_id')].[
+          InternetGatewayId,
+          join(',', Attachments[].VpcId)
       ]"
   done | column -s$'\t' -t
 }
@@ -237,18 +240,19 @@ vpc-route-tables(){
   #     $ vpcs | vpc-route-tables
   #     rtb-8e841c39  vpc-018d9739  NO_NAME
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
   for vpc_id in $vpc_ids; do
     aws ec2 describe-route-tables                             \
       --output text                                           \
-      --query "RouteTables[?VpcId=='$vpc_id'].[
-        RouteTableId,
-        VpcId,
-        join(',', [Tags[?Key=='Name'].Value || 'NO_NAME'][])
-      ]"              |
+      --query "
+        RouteTables[?VpcId=='$vpc_id'].[
+          RouteTableId,
+          VpcId,
+          join(',', [Tags[?Key=='Name'].Value || 'NO_NAME'][])
+        ]"            |
     column -s$'\t' -t
   done
 }
@@ -260,7 +264,7 @@ vpc-nat-gateways(){
   #
   #     USAGE: vpc-nat-gateways vpc-id [vpc-id]
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -288,7 +292,7 @@ vpc-subnets(){
   #     subnet-8bb774fe  vpc-018d9739  ap-southeast-2a  172.31.0.0/20   NO_NAME
   #     subnet-9eea2c07  vpc-018d9739  ap-southeast-2b  172.31.16.0/20  NO_NAME
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -309,7 +313,7 @@ vpc-network-acls(){
   #     $ vpcs | vpc-network-acls
   #     acl-ff4914d1  vpc-018d9739
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -327,7 +331,7 @@ vpc-rds(){
   #
   #     USAGE: vpc-rds vpc-id [vpc-id]
 
-  local vpc_ids="$(__bma_read_inputs $@)"
+  local vpc_ids="$@ $(skimstdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id


### PR DESCRIPTION
**Massive refactor - would appreciate if people try it out and report any problems**

Replace  `__bma_read_stdin` with `skimstdin` and reduce it to a one line function.

This forms part of a reference implementation of `pipe-skimming`, which involves commands
appending the first token from each line of STDIN to their argument list. Blog post to follow.

```shell
skimstdin() {
  # Return the first token from each line of STDIN
  [[ -t 0 ]] || awk 'ORS=" " { print $1 }'
}
```

There's a bunch of other tidy up to bring older functions in line with more recent conventions in the project. It's some a motherload of a change and will need further review and testing.