### PR TITLE
s/skimstdin/skim-stdin/g

### DIFF
--- a/lib/asg-functions
+++ b/lib/asg-functions
@@ -8,7 +8,7 @@ asgs() {
 
   # List EC2 Autoscaling Groups
 
-  local asg_names=$(skimstdin)
+  local asg_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   # shellcheck disable=SC2086
@@ -31,7 +31,7 @@ asg-capacity() {
 
   # List min, desired and maximum capacities of EC2 Autoscaling Group(s)
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
@@ -54,7 +54,7 @@ asg-desired-size-set() {
 
   local capacity="$1"
   shift
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -72,7 +72,7 @@ asg-instances() {
 
   # List instances of autoscaling group(s)
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z "$asg_names" ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
@@ -95,7 +95,7 @@ asg-launch-configuration() {
 
   # List Launch Configurations of Autoscaling Group(s)
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z "$asg_names" ]] && __bma_usage "auto-scaling-group" && return 1
 
   # shellcheck disable=SC2086
@@ -119,7 +119,7 @@ launch-configurations() {
 
   # List Launch Configurations
 
-  local launch_configuration_names=$(skimstdin)
+  local launch_configuration_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws autoscaling describe-launch-configurations                    \
@@ -139,7 +139,7 @@ launch-configuration-asgs() {
 
   # List EC2 Autoscaling Groups of Launch Configuration(s)
 
-  local launch_configuration_names="$@ $(skimstdin)"
+  local launch_configuration_names="$@ $(skim-stdin)"
   if [[ -z $launch_configuration_names ]] ; then
     __bma_usage "launch_configuration [launch_configuration]"
     return 1
@@ -165,7 +165,7 @@ asg-max-size-set() {
 
   local capacity="$1"
   shift
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -186,7 +186,7 @@ asg-min-size-set() {
 
   local capacity="$1"
   shift
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   if [[ -z $asg_names ]] || [[ -z $capacity ]] || [[ $capacity =~ [^0-9]+ ]]; then
     __bma_usage "capacity asg_name [asg_name]"
     return 1
@@ -206,7 +206,7 @@ asg-processes_suspended() {
   # List suspended processes of an autoscaling group
 
   # TODO: fix the output
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
@@ -225,7 +225,7 @@ asg-resume() {
 
   # Resume all processes of an autoscaling group
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name
@@ -239,7 +239,7 @@ asg-suspend() {
 
   # Suspend all processes of an autoscaling group
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name
@@ -254,7 +254,7 @@ asg-stack() {
 
   # List CloudFormation stack for asg(s)
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   # shellcheck disable=SC2086
@@ -273,7 +273,7 @@ asg-scaling-activities() {
 
   # List scaling activities for Autoscaling Group(s)
 
-  local asg_names="$@ $(skimstdin)"
+  local asg_names="$@ $(skim-stdin)"
   [[ -z $asg_names ]] && __bma_usage "asg_name [asg_name]" && return 1
 
   local asg_name

--- a/lib/aws-account-functions
+++ b/lib/aws-account-functions
@@ -50,7 +50,7 @@ aws-account-each() {
   #     IAM Role that can assume a Role in each of the specified accounts.
   #     Check the source for more info.
 
-  local aws_account_ids="$(skimstdin)"
+  local aws_account_ids="$(skim-stdin)"
   local cmd=$@
   local assumed_role_name="${AWS_PANOPTICON_ROLE_NAME:-SecurityAuditor}"
   [[ -z $aws_account_ids ]] && __bma_usage "cmd # pipe in AWS_ACCOUNT_IDS" && return 1
@@ -87,7 +87,7 @@ aws-account-cost-explorer(){
   #     $ grep demo AWS_ACCOUNTS | aws-account-cost-explorer
   #     #=> Opens web browser to AWS Cost Explorer with accounts selected
 
-  local accounts_formatted="%22$(printf "$@ $(skimstdin)" | sed 's/ /%22,%22/g')%22"
+  local accounts_formatted="%22$(printf "$@ $(skim-stdin)" | sed 's/ /%22,%22/g')%22"
 
   local cmd_open="$(hash xdg-open &> /dev/null && echo 'xdg-open' || echo 'open')"
 
@@ -106,7 +106,7 @@ aws-account-cost-recommendations(){
   #     $ grep non_prod AWS_ACCOUNTS | aws-account-each stacks FAILED
   #     #=> Opens web browser to AWS Cost Recommendations with accounts selected
 
-  local accounts_formatted="%22$(printf "$@ $(skimstdin)" | sed 's/ /%22,%22/g')%22"
+  local accounts_formatted="%22$(printf "$@ $(skim-stdin)" | sed 's/ /%22,%22/g')%22"
 
   local cmd_open="$(hash xdg-open &> /dev/null && echo 'xdg-open' || echo 'open')"
 

--- a/lib/cert-functions
+++ b/lib/cert-functions
@@ -7,7 +7,7 @@ certs() {
 
   # List ACM Certificates
 
-  local cert_arns=$(skimstdin)
+  local cert_arns=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   local include_arn_bit=''
@@ -58,7 +58,7 @@ cert-users() {
   #
   #     USAGE: cert-users cert-arn [cert-arn]
 
-  local cert_arns="$@ $(skimstdin)"
+  local cert_arns="$@ $(skim-stdin)"
   [[ -z "$cert_arns" ]] && __bma_usage "cert-arn [cert-arn]" && return 1
 
   local cert_arns
@@ -81,7 +81,7 @@ cert-delete() {
   #
   #     USAGE: cert-delete cert-arn [cert-arn]
 
-  local cert_arns="$@ $(skimstdin)"
+  local cert_arns="$@ $(skim-stdin)"
   [[ -z "$cert_arns" ]] && __bma_usage "cert-arn [cert-arn]" && return 1
 
   echo "You are about to delete the following certificates:"

--- a/lib/cloudtrail-functions
+++ b/lib/cloudtrail-functions
@@ -10,7 +10,7 @@ cloudtrails() {
   #     $ cloudtrails
   #     failmode	failmode-cloudtrail	ap-southeast-2	IsMultiRegionTrail=true	IncludeGlobalServiceEvents=true
 
-  local cloudtrails="$(skimstdin)"
+  local cloudtrails="$(skim-stdin)"
   local filters=$(__bma_read_filters "$@")
 
   aws cloudtrail describe-trails          \
@@ -41,7 +41,7 @@ cloudtrail-status() {
   #
   #     USAGE: cloudtrail-status cloudtrail [cloudtrail]
 
-  local cloudtrails="$@ $(skimstdin)"
+  local cloudtrails="$@ $(skim-stdin)"
   [[ -z "$cloudtrails" ]] && __bma_usage "cloudtrail [cloudtrail]" && return 1
 
   local cloudtrail

--- a/lib/ecr-functions
+++ b/lib/ecr-functions
@@ -7,7 +7,7 @@ ecr-repositories() {
 
   # List ECR Repositories
 
-  local aws_account_id=$(skimstdin)
+  local aws_account_id=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws ecr describe-repositories          \
@@ -33,7 +33,7 @@ ecr-repository-images() {
     local registry_id=${1#registry=}
     shift
   fi
-  local repository_names="$@ $(skimstdin)"
+  local repository_names="$@ $(skim-stdin)"
 
   # XXX Display USAGE if no repository_names passed in
 

--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -14,7 +14,7 @@ elbs() {
   #     elb-MyLoadBalancer-1FNISWJN0W6N9  2019-12-13T10:24:55.220Z
   #     another-e-MyLoadBa-171CPCZF2E84T  2019-12-13T10:25:24.300Z
 
-  local elb_names=$(skimstdin)
+  local elb_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws elb describe-load-balancers           \
@@ -41,7 +41,7 @@ elb-dnsname(){
   #      elb-MyLoadBalancer-1FNISWJN0W6N9  elb-MyLoadBalancer-1FNISWJN0W6N9-563832045.ap-southeast-2.elb.amazonaws.com
   #      another-e-MyLoadBa-171CPCZF2E84T  another-e-MyLoadBa-171CPCZF2E84T-1832721930.ap-southeast-2.elb.amazonaws.com
 
-  local elb_names=$(skimstdin)
+  local elb_names=$(skim-stdin)
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-load-balancers           \
@@ -62,7 +62,7 @@ elb-instances() {
   #
   #      USAGE: elb-instances load-balancer [load-balancer]
 
-  local elb_names="$@ $(skimstdin)"
+  local elb_names="$@ $(skim-stdin)"
   [[ -z "${elb_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   local elb_name
@@ -92,7 +92,7 @@ elb-stack() {
   #     elb          elb-MyLoadBalancer-1FNISWJN0W6N9
   #     another-elb  another-e-MyLoadBa-171CPCZF2E84T
 
-  local elb_names="$@ $(skimstdin)"
+  local elb_names="$@ $(skim-stdin)"
   [[ -z "$elb_names" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-tags                                            \
@@ -118,7 +118,7 @@ elb-subnets() {
   #     huginn-ELB-BMD0QUX179PK      subnet-5e257318 subnet-7828cd0f subnet-c25fa0a7
   #     prometheus-ELB-C0FGVLGQ64UH  subnet-5e257318 subnet-7828cd0f subnet-c25fa0a7
 
-  local elb_names="$@ $(skimstdin)"
+  local elb_names="$@ $(skim-stdin)"
   [[ -z "$elb_names" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-load-balancers    \
@@ -143,7 +143,7 @@ elb-azs() {
   #     rails-demo-ELB-FRBEQPCYSZQD  ap-southeast-2a ap-southeast-2b ap-southeast-2c
   #     huginn-ELB-BMD0QUX179PK      ap-southeast-2a ap-southeast-2b ap-southeast-2c
 
-  local elb_names="$@ $(skimstdin)"
+  local elb_names="$@ $(skim-stdin)"
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elb describe-load-balancers          \

--- a/lib/elbv2-functions
+++ b/lib/elbv2-functions
@@ -14,7 +14,7 @@ elbv2s() {
   #     bash-my-aws      network      internet-facing  active        2020-01-04T11:18:49.733Z
   #     bash-my-aws-alb  application  internet-facing  provisioning  2020-01-04T11:29:45.030Z
 
-  local elbv2_names=$(skimstdin)
+  local elbv2_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws elbv2 describe-load-balancers \
@@ -44,7 +44,7 @@ elbv2-dnsname(){
   #     bash-my-aws      bash-my-aws-c23c598688520e51.elb.ap-southeast-2.amazonaws.com
   #     bash-my-aws-alb  bash-my-aws-alb-2036199590.ap-southeast-2.elb.amazonaws.com
 
-  local elbv2_names="$@ $(skimstdin)"
+  local elbv2_names="$@ $(skim-stdin)"
   [[ -z "${elbv2_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \
@@ -69,7 +69,7 @@ elbv2-subnets() {
   #     bash-my-aws      subnet-c25fa0a7
   #     bash-my-aws-alb  subnet-7828cd0f subnet-c25fa0a7
 
-  local elbv2_names="$@ $(skimstdin)"
+  local elbv2_names="$@ $(skim-stdin)"
   [[ -z "${elbv2_names}" ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \
@@ -94,7 +94,7 @@ elbv2-azs() {
   #     bash-my-aws      ap-southeast-2a
   #     bash-my-aws-alb  ap-southeast-2a ap-southeast-2b
 
-  local elb_names="$@ $(skimstdin)"
+  local elb_names="$@ $(skim-stdin)"
   [[ -z $elb_names ]] && __bma_usage "load-balancer [load-balancer]" && return 1
 
   aws elbv2 describe-load-balancers \

--- a/lib/iam-functions
+++ b/lib/iam-functions
@@ -18,7 +18,7 @@ iam-roles() {
   #     AWSBatchServiceRole                      AROAJJWRGUPTRXTV52TED  2017-03-09T05:31:39Z
   #     ecsInstanceRole                          AROAJFQ3WMZXESGIKW5YD  2017-03-09T05:31:39Z
 
-  local role_names=$(skimstdin)
+  local role_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws iam list-roles    \
@@ -41,7 +41,7 @@ iam-role-principal(){
   #
   #     USAGE: iam-role-principal role-name [role-name]
 
-  local role_names="$@ $(skimstdin)"
+  local role_names="$@ $(skim-stdin)"
   [[ -z "$role_names" ]] && __bma_usage "role-name [role-name]" && return 1
 
   aws iam list-roles                                                         \

--- a/lib/image-functions
+++ b/lib/image-functions
@@ -21,7 +21,7 @@ images() {
   # Trialing a different approach for grabbing resource ids from input.
   # As normal, you can pipe resource ids in as first token on each line.
   # We treat all args that don't start with ami- as owner identifiers.
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local image_ids=$(echo -n "$inputs" | tr ' ' '\n' | grep ami- | tr '\n' ' ')
   local owners=$(echo -n "$inputs" | tr ' ' '\n' | grep -v ami- | tr '\n' ' ')
 
@@ -55,7 +55,7 @@ image-deregister() {
   #
   #     USAGE: image-deregister image_id [image_id]
 
-  local image_ids="$@ $(skimstdin)"
+  local image_ids="$@ $(skim-stdin)"
   [[ -z "${image_ids}" ]] && __bma_usage "image_id" && return 1
 
   local image_id

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -20,7 +20,7 @@ instances() {
   #     i-89cefa9403373d7a5  ami-123456789012  t3.nano  running  postgres1  2019-12-10T08:17:20.000Z  ap-southeast-2a  None
   #     i-806d8f1592e2a2efd  ami-123456789012  t3.nano  running  postgres2  2019-12-10T08:17:22.000Z  ap-southeast-2a  None
 
-  local instance_ids=$(skimstdin)
+  local instance_ids=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-instances            \
@@ -49,7 +49,7 @@ instance-asg() {
   #
   #     USAGE: instance-asg instance-id [instance-id]
 
-  local instance_ids=$(skimstdin $@)
+  local instance_ids=$(skim-stdin $@)
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances      \
@@ -77,7 +77,7 @@ instance-az() {
   #     i-89cefa9403373d7a5  ap-southeast-2a
   #     i-806d8f1592e2a2efd  ap-southeast-2a
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances      \
@@ -113,7 +113,7 @@ instance-console() {
   #     Xen: 0000000000000000 - 000000006a400000 (usable)
   #     ...snip...
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   local instance_id
@@ -138,7 +138,7 @@ instance-dns() {
   #     i-89cefa9403373d7a5  ip-10-155-35-61.ap-southeast-2.compute.internal   ec2-54-214-206-114.ap-southeast-2.compute.amazonaws.com
   #     i-806d8f1592e2a2efd  ip-10-178-243-63.ap-southeast-2.compute.internal  ec2-54-214-244-90.ap-southeast-2.compute.amazonaws.com
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances         \
@@ -162,7 +162,7 @@ instance-health-set-unhealthy() {
   #
   #     USAGE: instance-health-set-unhealthy instance-id [instance-id]
 
-  local instances="$@ $(skimstdin)";
+  local instances="$@ $(skim-stdin)";
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   local health_status=Unhealthy
@@ -182,7 +182,7 @@ instance-iam-profile() {
   #
   #     USAGE: instance-iam-profile instance-id [instance-id]
 
-  local instances="$@ $(skimstdin)";
+  local instances="$@ $(skim-stdin)";
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances      \
@@ -209,7 +209,7 @@ instance-ip() {
   #     i-89cefa9403373d7a5  10.155.35.61   54.214.206.114
   #     i-806d8f1592e2a2efd  10.178.243.63  54.214.244.90
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances           \
@@ -237,7 +237,7 @@ instance-ssh() {
     local user=${1}
     shift
   fi
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   if [ -z $instance_ids ] ; then echo "Usage: $FUNCNAME [login] [instance-id] [instance-id]"; return 1; fi
 
   exec </dev/tty # reattach keyboard to STDIN
@@ -271,7 +271,7 @@ instance-ssh-details() {
   #
   #     USAGE: instance-ssh-details [login] [instance-id] [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z "${instance_ids}" ]] && __bma_usage "instance_id" && return 1
 
   aws ec2 describe-instances                                      \
@@ -299,7 +299,7 @@ instance-stack() {
   #     postgres1  i-89cefa9403373d7a5
   #     postgres2  i-806d8f1592e2a2efd
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                                         \
@@ -326,7 +326,7 @@ instance-start() {
   #     i-a8b8dd6783e1a40cc  PreviousState=stopped  CurrentState=pending
   #     i-5d74753e210bfe04d  PreviousState=stopped  CurrentState=pending
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 start-instances        \
@@ -352,7 +352,7 @@ instance-state() {
   #     i-89cefa9403373d7a5  running
   #     i-806d8f1592e2a2efd  running
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances        \
@@ -380,7 +380,7 @@ instance-stop() {
   #     i-a8b8dd6783e1a40cc  PreviousState=running  CurrentState=stopping
   #     i-5d74753e210bfe04d  PreviousState=running  CurrentState=stopping
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 stop-instances         \
@@ -402,7 +402,7 @@ instance-tags() {
   #
   #     USAGE: instance-tags instance-id [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                            \
@@ -432,7 +432,7 @@ instance-terminate() {
   #     i-01c7edb986c18c16a  PreviousState=terminated  CurrentState=terminated
   #     i-012dded46894dfa04  PreviousState=running     CurrentState=shutting-down
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to terminate the following instances:"
@@ -469,7 +469,7 @@ instance-termination-protection() {
   #     i-806d8f1592e2a2efd DisableApiTermination=false
   #     i-61e86ac6be1e2c193 DisableApiTermination=false
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   for instance_id in $instance_ids; do
@@ -494,7 +494,7 @@ instance-termination-protection-disable() {
   #
   #     USAGE: instance-termination-protection-disable instance-id [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to disable termination protection on the following instances:"
@@ -521,7 +521,7 @@ instance-termination-protection-enable() {
   #
   #     USAGE: instance-termination-protection-enable instance-id [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   echo "You are about to enable termination protection on the following instances:"
@@ -554,7 +554,7 @@ instance-type() {
   #     i-806d8f1592e2a2efd  t3.nano
   #     i-61e86ac6be1e2c193  t3.nano
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                                            \
@@ -577,7 +577,7 @@ instance-userdata() {
   #
   #     USAGE: instance-userdata instance-id [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
   local instance_id
   for instance_id in $instance_ids; do
@@ -603,7 +603,7 @@ instance-volumes() {
   #     i-89cefa9403373d7a5  vol-cf5ddae9
   #     i-806d8f1592e2a2efd  vol-38fd45c3
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances                                            \
@@ -626,7 +626,7 @@ instance-vpc() {
   #
   #     USAGE: instance-vpcs instance-id [instance-id]
 
-  local instance_ids="$@ $(skimstdin)"
+  local instance_ids="$@ $(skim-stdin)"
   [[ -z $instance_ids ]] && __bma_usage "instance-id [instance-id]" && return 1
 
   aws ec2 describe-instances     \

--- a/lib/keypair-functions
+++ b/lib/keypair-functions
@@ -13,7 +13,7 @@ keypairs() {
   #     alice  8f:85:9a:1e:6c:76:29:34:37:45:de:7f:8d:f9:70:eb
   #     bob    56:73:29:c2:ad:7b:6f:b6:f2:f3:b4:de:e4:2b:12:d4
 
-  local keypairs="$(skimstdin)"
+  local keypairs="$(skim-stdin)"
   local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-key-pairs                       \
@@ -101,7 +101,7 @@ keypair-delete() {
   #     yet-another-keypair
   #     Are you sure you want to continue? y
 
-  local keypairs="$@ $(skimstdin)"
+  local keypairs="$@ $(skim-stdin)"
   [[ -z $keypairs ]] && __bma_usage "key_name [key_name]" && return 1
 
   echo "You are about to delete the following EC2 SSH KeyPairs:"

--- a/lib/kms-functions
+++ b/lib/kms-functions
@@ -123,7 +123,7 @@ kms-alias-delete() {
   #     alias/foobar
   #     Are you sure you want to continue? y
 
-  local alias_names="$@ $(skimstdin)"
+  local alias_names="$@ $(skim-stdin)"
   [[ -z "$alias_names" ]] && __bma_usage "alias_name [alias_name]" && return 1
 
    echo "You are about to delete the following kms aliases:"
@@ -182,7 +182,7 @@ kms-key-details() {
 
   # List details for KMS Key(s)
 
-  local key_ids="$@ $(skimstdin)"
+  local key_ids="$@ $(skim-stdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids
@@ -212,7 +212,7 @@ kms-key-disable() {
   #
   #     $ kms-key-disable  9e94333b-8e85-497a-9791-e7c5edf9c35e
 
-  local key_ids="$@ $(skimstdin)"
+  local key_ids="$@ $(skim-stdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids
@@ -230,7 +230,7 @@ kms-key-enable() {
   #
   #     $ kms-key-enable  9e94333b-8e85-497a-9791-e7c5edf9c35e
 
-  local key_ids="$@ $(skimstdin)"
+  local key_ids="$@ $(skim-stdin)"
   [[ -z "$key_ids" ]] && __bma_usage "key_id [key_id]" && return 1
 
   local key_ids

--- a/lib/lambda-functions
+++ b/lib/lambda-functions
@@ -11,7 +11,7 @@ lambda-functions() {
   #     stars    2019-12-18T10:00:00.000+0000  python2.7  256
   #     stripes  2019-12-19T10:21:42.444+0000  python3.7  128
 
-  local function_names=$(skimstdin)
+  local function_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   local column_command
@@ -43,7 +43,7 @@ lambda-function-memory(){
   #
   #     USAGE: lambda-function-memory function [function]
 
-  local function_names="$@ $(skimstdin)"
+  local function_names="$@ $(skim-stdin)"
   [[ -z "$function_names" ]] && __bma_usage "function [function]" && return 1
 
   local column_command
@@ -75,7 +75,7 @@ lambda-function-memory-set(){
   local usage_msg="memory function [function]"
   [[ -z "${memory}" ]] && __bma_usage "$usage_msg" && return 1
 
-  local function_names="$@ $(skimstdin)"
+  local function_names="$@ $(skim-stdin)"
   [[ -z "${function_names}" && -t 0 ]] && __bma_usage "$usage_msg" && return 1
 
   local function_name
@@ -108,7 +108,7 @@ lambda-function-memory-step(){
   [[ -z "${memory_last}" ]] && __bma_usage $usage_msg && return 1
   # XXX check it's a valid memory size
 
-  local function_names="$@ $(skimstdin)"
+  local function_names="$@ $(skim-stdin)"
   [[ -z "${function_names}" && -t 0 ]] && __bma_usage $usage_msg && return 1
 
   echo "You are about to step memory for following functions:"

--- a/lib/log-functions
+++ b/lib/log-functions
@@ -13,7 +13,7 @@ log-groups() {
   #     /aws/lambda/stars   1576566745961  0  107460
   #     /aws/lambda/walk    1576567300172  0   11794
 
-  local log_group_names=$(skimstdin)
+  local log_group_names=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   local column_command

--- a/lib/region-functions
+++ b/lib/region-functions
@@ -40,7 +40,7 @@ region() {
   #     $ region
   #     ap-southeast-2
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   if [[ -z "$inputs" ]]; then
     echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
   else

--- a/lib/route53-functions
+++ b/lib/route53-functions
@@ -12,7 +12,7 @@ hosted-zones(){
   #     /hostedzone/Z1111111111111  3   NotPrivateZone  bash-my-aws.com.
   #     /hostedzone/Z2222222222222  3   NotPrivateZone  bashmyaws.com.
 
-  local ids=$(skimstdin)
+  local ids=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws route53 list-hosted-zones \
@@ -43,7 +43,7 @@ hosted-zone-ns-records(){
   #     bash-my-aws.org. 300 IN NS	ns-362.awsdns-45.com.
   #     bash-my-aws.org. 300 IN NS	ns-1464.awsdns-55.org.
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local hosted_zone_id=$(echo "$inputs" | awk '{print $1}')
   [[ -z "$hosted_zone_id" ]] && __bma_usage "hosted-zone-id" && return 1
 

--- a/lib/s3-functions
+++ b/lib/s3-functions
@@ -12,7 +12,7 @@ buckets() {
   #     backups     2019-12-20  08:24:44.351215
   #     archive     2019-12-20  08:24:57.567652
 
-  local buckets=$(skimstdin)
+  local buckets=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws s3api list-buckets \
@@ -39,7 +39,7 @@ bucket-acls() {
   #     permission to the Amazon S3 Log Delivery group to write access log
   #     objects to your bucket. [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-alternatives-guidelines.html)
 
-  local buckets="$@ $(skimstdin)"
+  local buckets="$@ $(skim-stdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   local bucket
@@ -68,7 +68,7 @@ bucket-remove() {
   #     Are you sure you want to continue? y
   #     remove_bucket failed: s3://another-example-bucket An error occurred (BucketNotEmpty) when calling the DeleteBucket operation: The bucket you tried to delete is not empty
 
-  local buckets="$@ $(skimstdin)"
+  local buckets="$@ $(skim-stdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   echo "You are about to remove the following buckets:"
@@ -98,7 +98,7 @@ bucket-remove-force() {
   #     delete: s3://another-example-bucket/aliases
   #     remove_bucket: another-example-bucket
 
-  local buckets="$@ $(skimstdin)"
+  local buckets="$@ $(skim-stdin)"
   [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
 
   echo "You are about to delete all objects from and remove the following buckets:"

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -5,7 +5,7 @@
 # Used by bash-my-aws functions to work with stdin and arguments.
 
 
-skimstdin() {
+skim-stdin() {
   # Return the first token from each line of STDIN
   [[ -t 0 ]] || awk 'ORS=" " { print $1 }'
 }
@@ -47,7 +47,7 @@ __bma_read_inputs() {
 
 
 __bma_read_stdin() {
-  # deprecated - use skimstdin
+  # deprecated - use skim-stdin
   [[ -t 0 ]] ||
     cat                  |
       awk '{ print $1 }' |

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -53,7 +53,7 @@ stacks() {
   #     postgres1  CREATE_COMPLETE  2019-04-14T15:22:44Z  NEVER_UPDATED  NOT_NESTED
   #     postgres2  CREATE_COMPLETE  2019-05-18T05:45:50Z  NEVER_UPDATED  NOT_NESTED
 
-  local stack_names=$(skimstdin) # Filter by stack-names from STDIN (optional)
+  local stack_names=$(skim-stdin) # Filter by stack-names from STDIN (optional)
   local filters=$(__bma_read_filters $@) # Filter output by arguments (optional)
 
   aws cloudformation list-stacks                      \
@@ -104,7 +104,7 @@ stack-arn() {
   #     arn:aws:cloudformation:us-east-1:000000000000:stack/postgres2/7420bbd4-3026-444f-b55b-fa0a9d564730
   #     arn:aws:cloudformation:us-east-1:000000000000:stack/prometheus-web/805e081c-b8eb-4f6c-9872-2b5cddc77fba
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   local stack
   for stack in $stacks; do
@@ -120,7 +120,7 @@ stack-cancel-update() {
 
   # Cancel an in-progress stack update
 
-  local stack=$(_bma_stack_name_arg "$@ $(skimstdin)")
+  local stack=$(_bma_stack_name_arg "$@ $(skim-stdin)")
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
   aws cloudformation cancel-update-stack --stack-name "$stack"
@@ -299,7 +299,7 @@ stack-delete() {
 
   # *Note that the error reported at the end of `stack-delete` command is just AWSCLI saying it can't find the stack anymore.*
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   local stack
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   if ! [ -t 0 ] ; then # if STDIN is not a terminal...
@@ -332,7 +332,7 @@ stack-exports() {
 }
 
 stack-recreate() {
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z "${stack}" ]] && __bma_usage "stack" && return 1
 
@@ -357,7 +357,7 @@ stack-failure() {
 
   # Return reason a stack failed to update/create/delete
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z "${stack}" ]] && __bma_usage "stack" && return 1
 
@@ -379,7 +379,7 @@ stack-events() {
   #
   #     USAGE: stack-events stack
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -415,7 +415,7 @@ stack-resources() {
   #     i-2aa95cc214a461398  AWS::EC2::Instance  prometheus-web
 
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local stack
@@ -445,7 +445,7 @@ stack-asgs() {
   #     asg-bash-my-aws-AutoScalingGroup-MSBCWRTI3PVM  AWS::AutoScaling::AutoScalingGroup  asg-bash-my-aws
   #     asg2-AutoScalingGroup-1FHUVUJ7SLPU7            AWS::AutoScaling::AutoScalingGroup  asg2
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   stack-resources $stacks                 |
@@ -464,7 +464,7 @@ stack-asg-instances() {
   #     i-06ee900565652ecc5  ami-0119aa4d67e59007c  t3.nano  running  asg-bash-my-aws  2019-12-13T03:15:22.000Z  ap-southeast-2c  vpc-deb8edb9
   #     i-01c7edb986c18c16a  ami-0119aa4d67e59007c  t3.nano  running  asg2             2019-12-13T03:37:51.000Z  ap-southeast-2c  vpc-deb8edb9
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local asgs=$(stack-asgs $stacks)
@@ -484,7 +484,7 @@ stack-elbs() {
   #     elb-MyLoadBalancer-NA5S72MLA5KI   AWS::ElasticLoadBalancing::LoadBalancer  elb-stack-1
   #     load-bala-MyLoadBa-11HZ0DHUHJZZI  AWS::ElasticLoadBalancing::LoadBalancer  elb-stack-2
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   stack-resources $stacks                      |
@@ -506,7 +506,7 @@ stack-instances() {
   #     i-5d74753e210bfe04d  ami-123456789012  t3.nano  running  postgres2       2019-12-13T02:24:34.000Z  ap-southeast-2a  None
   #     i-2aa95cc214a461398  ami-123456789012  t3.nano  running  prometheus-web  2019-12-13T02:24:36.000Z  ap-southeast-2a  None
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local instance_ids=$(stack-resources $stacks | grep AWS::EC2::Instance | awk '{ print $1 }')
@@ -516,7 +516,7 @@ stack-instances() {
 
 stack-parameters() {
   # List parameters of stack
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -531,7 +531,7 @@ stack-status() {
 
   # List status of stack
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
 
   local stack
@@ -551,7 +551,7 @@ stack-tag() {
   local tag=$1
   shift 1
   [[ -z "${tag}" ]] && __bma_usage "tag-key stack [stack]" && return 1
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
   [[ -z ${stacks} && -t 0 ]] && __bma_usage "tag-key stack [stack]" && return 1
   local stack
   for stack in $stacks; do
@@ -579,7 +579,7 @@ stack-tag() {
 # XXX   [[ -z "${tag_key}" ]]    && __bma_usage $usage_msg && return 1
 # XXX   [[ -z "${tag_value}" ]] && __bma_usage $usage_msg && return 1
 # XXX 
-# XXX   local stacks="$@ $(skimstdin)"
+# XXX   local stacks="$@ $(skim-stdin)"
 # XXX   [[ -z "${stacks}" && -t 0 ]] && __bma_usage $usage_msg && return 1
 # XXX 
 # XXX   local stack
@@ -627,7 +627,7 @@ stack-tag() {
 # XXX   shift 1
 # XXX   [[ -z "${tag_key}" ]] && __bma_usage "tag-key stack [stack]" && return 1
 # XXX 
-# XXX   local stacks="$@ $(skimstdin)"
+# XXX   local stacks="$@ $(skim-stdin)"
 # XXX   [[ -z "${stacks}" ]] && __bma_usage "tag-key stack [stack]" && return 1
 # XXX 
 # XXX   local stack
@@ -662,7 +662,7 @@ stack-tail() {
 
   # Show all events for CF stack until update completes or fails.
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -696,7 +696,7 @@ stack-template() {
 
   # Return template of a stack
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
 
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
@@ -712,7 +712,7 @@ stack-tags() {
 
   # List stack-tags applied to a stack
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
 
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
@@ -729,7 +729,7 @@ stack-tags-text() {
 
   # List stack-tags applied to a stack on a single line
 
-  local stacks="$@ $(skimstdin)"
+  local stacks="$@ $(skim-stdin)"
 
   [[ -z ${stacks} ]] && __bma_usage "stack [stack]" && return 1
   local stack
@@ -749,7 +749,7 @@ stack-outputs() {
 
   # List outputs of a stack
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   local stack=$(_bma_stack_name_arg ${inputs})
   [[ -z ${stack} ]] && __bma_usage "stack" && return 1
 
@@ -770,7 +770,7 @@ stack-validate() {
 
   # Validate a stack template
 
-  local inputs=$(printf "$@ $(skimstdin)" | cut -f1)
+  local inputs=$(printf "$@ $(skim-stdin)" | cut -f1)
   [[ -z "$inputs" ]] && __bma_usage "template-file" && return 1
   size=$(wc -c <"$inputs")
   if [[ $size -gt 51200 ]]; then
@@ -811,7 +811,7 @@ stack-diff(){
   #        {
   #          "ParameterKey": "InstanceType",
 
-  local inputs="$@ $(skimstdin)"
+  local inputs="$@ $(skim-stdin)"
   [[ -z "$inputs" ]] && __bma_usage "stack [template-file]" && return 1
   _bma_stack_diff_template $inputs
   [[ $? -ne 0 ]] && __bma_usage "stack [template-file]" && return 1

--- a/lib/vpc-functions
+++ b/lib/vpc-functions
@@ -41,7 +41,7 @@ subnets(){
   #     subnet-8bb774fe  vpc-018d9739  ap-southeast-2a  172.31.0.0/20   NO_NAME
   #     subnet-9eea2c07  vpc-018d9739  ap-southeast-2b  172.31.16.0/20  NO_NAME
 
-  local subnet_ids=$(skimstdin)
+  local subnet_ids=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-subnets          \
@@ -67,7 +67,7 @@ vpcs() {
   #     $ vpcs
   #     vpc-018d9739  default-vpc  NO_NAME  172.31.0.0/16  NO_STACK  NO_VERSION
 
-  local vpc_ids=$(skimstdin)
+  local vpc_ids=$(skim-stdin)
   local filters=$(__bma_read_filters $@)
 
   aws ec2 describe-vpcs       \
@@ -96,7 +96,7 @@ vpc-azs() {
   #     $ vpcs | vpc-azs
   #     vpc-018d9739 ap-southeast-2a ap-southeast-2b ap-southeast-2c
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -117,7 +117,7 @@ vpc-az-count() {
   #     $ vpcs | vpc-az-count
   #     vpc-018d9739 3
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -133,7 +133,7 @@ vpc-lambda-functions(){
   #
   #     USAGE: vpc-lambda-functions vpc-id [vpc-id]
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -168,7 +168,7 @@ vpc-endpoints(){
   #
   #     USAGE: vpc-endpoints [filter]
 
-  local vpc_endpoint_ids=$(skimstdin)
+  local vpc_endpoint_ids=$(skim-stdin)
   local filters=$(__bma_read_filters $@ $vpc_ids)
 
   aws ec2 describe-vpc-endpoints                \
@@ -215,7 +215,7 @@ vpc-igw() {
   #
   #     USAGE: vpc-igw vpc-id [vpc-id]
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -240,7 +240,7 @@ vpc-route-tables(){
   #     $ vpcs | vpc-route-tables
   #     rtb-8e841c39  vpc-018d9739  NO_NAME
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -264,7 +264,7 @@ vpc-nat-gateways(){
   #
   #     USAGE: vpc-nat-gateways vpc-id [vpc-id]
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -292,7 +292,7 @@ vpc-subnets(){
   #     subnet-8bb774fe  vpc-018d9739  ap-southeast-2a  172.31.0.0/20   NO_NAME
   #     subnet-9eea2c07  vpc-018d9739  ap-southeast-2b  172.31.16.0/20  NO_NAME
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -313,7 +313,7 @@ vpc-network-acls(){
   #     $ vpcs | vpc-network-acls
   #     acl-ff4914d1  vpc-018d9739
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id
@@ -331,7 +331,7 @@ vpc-rds(){
   #
   #     USAGE: vpc-rds vpc-id [vpc-id]
 
-  local vpc_ids="$@ $(skimstdin)"
+  local vpc_ids="$@ $(skim-stdin)"
   [[ -z "$vpc_ids" ]] && __bma_usage "vpc-id [vpc-id]" && return 1
 
   local vpc_id


### PR DESCRIPTION
Make function name more readable

`skimstdin` was only added 5 days ago so I'm taking the unusual step of *not* keeping it around after the rename.