### PR TITLE
Send column error message to dev-null due to "column" version in Ubuntu

### DIFF
--- a/lib/lambda-functions
+++ b/lib/lambda-functions
@@ -15,7 +15,7 @@ lambda-functions() {
   local filters=$(__bma_read_filters $@)
 
   local column_command
-  if column --help | grep -- --table-right > /dev/null; then
+  if column --help 2>/dev/null | grep -- --table-right > /dev/null; then
     column_command='column --table --table-right 3,4'
   else
     column_command='column -t'

--- a/lib/log-functions
+++ b/lib/log-functions
@@ -17,7 +17,7 @@ log-groups() {
   local filters=$(__bma_read_filters $@)
 
   local column_command
-  if column --help | grep -- --table-right > /dev/null; then
+  if column --help 2>/dev/null| grep -- --table-right > /dev/null; then
     column_command='column --table --table-right 3,4'
   else
     column_command='column -t'


### PR DESCRIPTION
Due to `column` command version in Ubuntu 18.04, that doesn't have the `--help` option, `lambda-functions` returns the followingo error:

![image](https://user-images.githubusercontent.com/1218747/72334911-dab03300-369c-11ea-97b7-e9e13f1ab802.png)

After the error, lambda functions are listed.

To avoid this it is just a matter to send column errors to `/dev/null` when the test to determine $column_command is done. After the changes, `lambda-functions` works fine:

![image](https://user-images.githubusercontent.com/1218747/72335060-1c40de00-369d-11ea-92b2-d0035eec0b29.png)
