### PR TITLE
Prevent wildcard expansion in bin/bma

### DIFF
--- a/bin/bma
+++ b/bin/bma
@@ -25,4 +25,4 @@ if [[ $BMA_USE_LOCALSTACK == 'true' ]]; then
   export aws
 fi
 
-$@
+"$@"


### PR DESCRIPTION
When running a command via `bin/bma` (the default when using aliases) we don't want bash to expand wildcards (globbing).

While it's unlikely that `*`s will be provided as arguments to `bin/bma` it's better to be safe than sorry.