### PR TITLE
Update instance-ssh-details to match instance-ssh

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -274,6 +274,10 @@ instance-ssh-details() {
   #
   #     USAGE: instance-ssh-details [login] [instance-id] [instance-id]
 
+  if [[ $1 != *i-* ]]; then
+    local user=${1}
+    shift
+  fi
   local instance_ids=$(skim-stdin "$@")
   [[ -z "${instance_ids}" ]] && __bma_usage "instance_id" && return 1
 


### PR DESCRIPTION
Resolves #290 by copying the 'i-*' string detection from instance-ssh() to instance-ssh-details().

Help Text had already mentioned [login] so I assume that part can stay unchanged.