### PR TITLE
AWS was expecting a PEM format for `Get Windows Password`

### DIFF
--- a/lib/keypair-functions
+++ b/lib/keypair-functions
@@ -76,7 +76,7 @@ keypair-create() {
   fi
 
   echo "Creating ${KEY_DIR}/${KEY_NAME}"
-  ssh-keygen -t rsa -b 4096 -o -a 100 -f "${KEY_DIR}/${KEY_NAME}"
+  ssh-keygen -t rsa -m PEM -b 4096 -o -a 100 -f "${KEY_DIR}/${KEY_NAME}"
   chmod 0600 "${KEY_DIR}/${KEY_NAME}"
   aws ec2 import-key-pair                                 \
     --key-name "$KEY_NAME"                                \


### PR DESCRIPTION
EC2's `Get Windows Password` expects you to provide a key in
PEM format.

So instead of:

    -----BEGIN OPENSSH PRIVATE KEY-----

you'll see:

    -----BEGIN RSA PRIVATE KEY-----