### PR TITLE
aws-cli-v2 expects blobs to be base64 encoded

### DIFF
--- a/lib/kms-functions
+++ b/lib/kms-functions
@@ -19,7 +19,11 @@ kms-encrypt() {
   if [[ -n $2 ]]; then
     plaintext="fileb://${2}"
   elif [[ ! -t 0 ]]; then
-    plaintext=$(cat)
+    if __bma-using-aws-cli-v1; then
+      plaintext="$(cat)"
+    else
+      plaintext="$(base64)"
+    fi
   fi
 
   [[ -z "$plaintext" ]] && __bma_usage "key_id/alias_id [plaintext_file]" && return 1

--- a/lib/shared-functions
+++ b/lib/shared-functions
@@ -31,6 +31,10 @@ skim-stdin() {
 
 }
 
+__bma-using-aws-cli-v1() {
+  aws --version | grep 'aws-cli/1' &>/dev/null
+}
+
 
 __bma_read_filters() {
 


### PR DESCRIPTION
`kms-encrypt` will base64 encode input from STDIN (unless awscli version 1 is being used).

[aws-cli-v2 expects blobs to be base64 encoded](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam)

Part of #293 