### PR TITLE
[WIP] Suggestion to save money by not using KMS to encrypt param

### DIFF
--- a/cloudformation/stars.yml
+++ b/cloudformation/stars.yml
@@ -7,6 +7,9 @@ Parameters:
     Type: String
     Default: bash-my-aws
 
+  # A KMS customer managed key (CMK) costs $1 a month
+  # This feels like overkill for the risk that someone will SPAM my Slack channel.
+  # TODO: switch to an unencrypted parameter
   KmsEncryptedHookUrl:
     Description: Slack integration URL
     Type: String


### PR DESCRIPTION
Not yet implemented

I discovered KMS Customer Managed Keys cost $1 a month.
It might not seem like much but keeping the Slack Webhook in an unencrypted CloudFormation parameter is not a huge risk.
Would be good to provide an alternative that decrypts parameter if it's encrypted, otherwise uses as is.