### PR TITLE
Update stacks query when pass thru stdin

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -73,7 +73,7 @@ stacks() {
       UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS    \
       UPDATE_ROLLBACK_FAILED                          \
       UPDATE_ROLLBACK_IN_PROGRESS                     \
-    --query "StackSummaries[${stack_names:+?contains(['${stack_names// /"','"}'], StackName)}][
+    --query "StackSummaries[${stack_names:+?contains(['${stack_names// /','}'], StackName)}][
                StackName ,
                StackStatus,
                CreationTime,


### PR DESCRIPTION
# What 

- Fix `stacks` so it will generate the query correctly when stdin has more than ONE stack.

#### BEFORE:

```bash
$ vpcs | awk '{print $5}' | stacks
# ?contains(['vpc-stack-name-1"','"vpc-stack-name-2"','"vpc-stack-name-3"','"vpc-stack-name-4"','"vpc-stack-name-5'], StackName)

$ vpcs | tail -n 1 | awk '{print $5}' | stacks
# ?contains(['vpc-stack-name-5'], StackName)
```

#### AFTER:

```bash
$ vpcs | awk '{print $5}' | stacks

# ?contains(['vpc-stack-name-1','vpc-stack-name-2','vpc-stack-name-3','vpc-stack-name-4','vpc-stack-name-5'], StackName)

$ vpcs | tail -n 1 | awk '{print $5}' | stacks
# ?contains(['vpc-stack-name-5'], StackName)
```

# Why

- When using `stack-delete` it gets [piped into `stacks`](https://github.com/bash-my-aws/bash-my-aws/blob/6934b15b0d8338b6a80b781175d39b8022696a5e/lib/stack-functions#L308), if there is **more than one** stack-name, currently it will not print anything when prompted.
