### PR TITLE
Add ResourceStatus to stack-resources

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -426,6 +426,7 @@ stack-resources() {
         StackResources[].[
           PhysicalResourceId,
           ResourceType,
+          ResourceStatus,
           '$stack'
       ]"              |
     column -s$'\t' -t


### PR DESCRIPTION
This is nice for stacks that are in a `DELETE_FAILED` status

```
✗ stack-resources snip
sg-snip                        AWS::EC2::SecurityGroup         DELETE_COMPLETE  snip
snip-development               AWS::EKS::Cluster               DELETE_FAILED    snip
sg-snip                        AWS::EC2::SecurityGroup         DELETE_FAILED    snip
IngressDefaultClusterToNodeSG  AWS::EC2::SecurityGroupIngress  DELETE_COMPLETE  snip
IngressInterNodeGroupSG        AWS::EC2::SecurityGroupIngress  DELETE_COMPLETE  snip
IngressNodeToDefaultClusterSG  AWS::EC2::SecurityGroupIngress  DELETE_COMPLETE  snip
```