### PR TITLE
Update build scripts

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,5 +1,7 @@
-# GENERATED ALIASES FOR BASH-MY-AWS
+# DO NOT MANUALLY MODIFY THIS FILE.
+# Use 'scripts/build' to regenerate if required.
 
+alias __bma-using-aws-cli-v1='~/.bash-my-aws/bin/bma __bma-using-aws-cli-v1'
 alias __bma_error='~/.bash-my-aws/bin/bma __bma_error'
 alias __bma_read_filters='~/.bash-my-aws/bin/bma __bma_read_filters'
 alias __bma_read_inputs='~/.bash-my-aws/bin/bma __bma_read_inputs'
@@ -165,7 +167,7 @@ alias vpcs='~/.bash-my-aws/bin/bma vpcs'
 # We'll find a less suprising place for this in future
 # region() needs to be a function in order to let it
 # set AWS_DEFAULT_REGION in the current shell
-function region() {
+function region() { 
     local inputs=$(skim-stdin "$@");
     if [[ -z "$inputs" ]]; then
         echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}";

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,3 +1,6 @@
+# DO NOT MANUALLY MODIFY THIS FILE.
+# Use 'scripts/build' to regenerate if required.
+
 bma_path="${HOME}/.bash-my-aws"
 _bma_asgs_completion() {
   local command="$1"
@@ -110,7 +113,7 @@ _bma_completion() {
 _bma_functions_completion() {
   local word all_funcs
   word="$1"
-  all_funcs=$(echo "type" && cat "${bma_path}/functions")
+  all_funcs=$(echo "type" && cat "${bma_path}/functions" | command grep -v "^#")
   COMPREPLY=($(compgen -W "${all_funcs}" -- ${word}))
   return
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -604,7 +604,7 @@ List details needed to SSH into EC2 Instance(s)
 
 Establish SSM connection to EC2 Instance(s)
 
-    USAGE: instance-ssm [instance-id] [instance-id]
+    USAGE: instance-ssm instance-id [instance-id]
 
 
 ### instance-stack

--- a/functions
+++ b/functions
@@ -1,3 +1,7 @@
+# DO NOT MANUALLY MODIFY THIS FILE.
+# Use 'scripts/build' to regenerate if required.
+
+__bma-using-aws-cli-v1
 __bma_error
 __bma_read_filters
 __bma_read_inputs

--- a/scripts/build
+++ b/scripts/build
@@ -16,16 +16,24 @@ for f in $project_root/lib/*-functions; do source "$f"; done
 # all function after loading BMA functions
 funcs_after_bma=$(compgen -A function)
 
-echo "${funcs_before_bma}" "${funcs_after_bma}" |
-  tr ' ' '\n'                                   |
-  awk 'NF'                                      |
-  LC_ALL=C sort                                 |
-  uniq -u > "$funcs_destination"
+# Generate the functions file
+
+{
+  echo "# DO NOT MANUALLY MODIFY THIS FILE."
+  echo "# Use 'scripts/build' to regenerate if required."
+  echo ""
+  echo "${funcs_before_bma}" "${funcs_after_bma}" |
+    tr ' ' '\n'                                   |
+    awk 'NF'                                      |
+    LC_ALL=C sort                                 |
+    uniq -u
+} > "$funcs_destination"
 
 
 # Generate the aliases file
 {
-  echo "# GENERATED ALIASES FOR BASH-MY-AWS"
+  echo "# DO NOT MANUALLY MODIFY THIS FILE."
+  echo "# Use 'scripts/build' to regenerate if required."
   echo ""
 } > "$aliases_destination"
 
@@ -51,6 +59,8 @@ for fnc_name in $fncs_to_clone; do
     function_body=$(type "$fnc_name" | tail -n +3)
     printf "function %s() %s" "$fnc_name" "$function_body" >> "$aliases_destination"
 done;
+
+echo "" >> "$aliases_destination"
 
 ${project_root}/scripts/build-completions > "$completion_destination"
 

--- a/scripts/build-completions
+++ b/scripts/build-completions
@@ -3,6 +3,9 @@
 bma_path="$(cd "$(dirname "$0")/.." && pwd)"
 
 cat <<EOF
+# DO NOT MANUALLY MODIFY THIS FILE.
+# Use 'scripts/build' to regenerate if required.
+
 bma_path="\${HOME}/.bash-my-aws"
 EOF
 
@@ -20,8 +23,6 @@ for type in "${available_completions[@]}"; do
 done
 
 cat "${bma_path}/scripts/completions/bma-completion"
-
-
 
 # dont add auto_completions for these functions
 funcs_no_completion=(

--- a/scripts/completions/bma-completion
+++ b/scripts/completions/bma-completion
@@ -14,7 +14,7 @@ _bma_completion() {
 _bma_functions_completion() {
   local word all_funcs
   word="$1"
-  all_funcs=$(echo "type" && cat "${bma_path}/functions")
+  all_funcs=$(echo "type" && cat "${bma_path}/functions" | command grep -v "^#")
   COMPREPLY=($(compgen -W "${all_funcs}" -- ${word}))
   return
 }

--- a/test/check-completions
+++ b/test/check-completions
@@ -5,6 +5,7 @@ bma_path=$(cd $(dirname $0)/.. && pwd)
 # function in bma
 bma_funcs=$(
   cat "${bma_path}/functions" \
+  | grep -vE "^#" \
   | grep -vE "^__bma" \
   | grep -vE "^_bma"
 )


### PR DESCRIPTION
## What 

Update the build scripts.

## How 

Added the following text to each of the "generated" files: 

> \# DO NOT MANUALLY MODIFY THIS FILE.
> \# Use 'scripts/build' to regenerate if required.

i.e. `functions`, `aliases` and `bash_completion.sh`

Feel free to suggest better wordings.

Would be great if someone could also give this a test run ~

## Why 

- Would serve as a good reminder that there is a build script.

PS. Seems like it fixed the documentation too for `instance-ssm` 😄 