### PR TITLE
Make sure that AWS_DEFAULT_REGION variable is exported

### DIFF
--- a/aliases
+++ b/aliases
@@ -172,6 +172,6 @@ function region() {
     if [[ -z "$inputs" ]]; then
         echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}";
     else
-        AWS_DEFAULT_REGION="$inputs";
+        export AWS_DEFAULT_REGION="$inputs";
     fi
 }

--- a/lib/region-functions
+++ b/lib/region-functions
@@ -45,7 +45,7 @@ region() {
   if [[ -z "$inputs" ]]; then
     echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
   else
-    AWS_DEFAULT_REGION="$inputs"
+    export AWS_DEFAULT_REGION="$inputs"
   fi
 }
 
@@ -62,6 +62,7 @@ region-each() {
   #     example-ec2-us-west-2       CREATE_COMPLETE  2011-05-23T15:47:44Z  NEVER_UPDATED  NOT_NESTED  #us-west-2
 
   local old_aws_default_region="$AWS_DEFAULT_REGION"
+  export AWS_DEFAULT_REGION
   for AWS_DEFAULT_REGION in $(regions); do
     eval "$@" | sed "s/$/ #${AWS_DEFAULT_REGION}/"
   done


### PR DESCRIPTION
Shell doesn't pass environment variables to sub-processes unless they are exported.
```
$ A=1
$ bash -c 'echo $A'

$ export A  
$ bash -c 'echo $A'
1
```

Both `region` and `region-each` functions set `AWS_DEFAULT_REGION` variable, but they do not export it, hence they are not passed into `bma` sub-process and neither of those functions work as expected.