### PR TITLE
Add some stack-status filter values to stacks()

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -63,11 +63,18 @@ stacks() {
       CREATE_IN_PROGRESS                              \
       DELETE_FAILED                                   \
       DELETE_IN_PROGRESS                              \
+      IMPORT_IN_PROGRESS                              \
+      IMPORT_COMPLETE                                 \
+      IMPORT_ROLLBACK_IN_PROGRESS                     \
+      IMPORT_ROLLBACK_FAILED                          \
+      IMPORT_ROLLBACK_COMPLETE                        \
+      REVIEW_IN_PROGRESS                              \
       ROLLBACK_COMPLETE                               \
       ROLLBACK_FAILED                                 \
       ROLLBACK_IN_PROGRESS                            \
       UPDATE_COMPLETE                                 \
       UPDATE_COMPLETE_CLEANUP_IN_PROGRESS             \
+      UPDATE_FAILED                                   \
       UPDATE_IN_PROGRESS                              \
       UPDATE_ROLLBACK_COMPLETE                        \
       UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS    \


### PR DESCRIPTION
Fixes #316

> The output of 'stacks' does not currently include stacks that were produced via an import of existing resources (stack-status 'IMPORT_COMPLETE').
> Could/should this be added to the filter?