### PR TITLE
Make stack-diff output prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ postgres02  DELETE_COMPLETE  2011-05-23T15:47:44Z  NEVER_UPDATED  NOT_NESTED
 * [bash](https://www.gnu.org/software/bash/)
 * [jq-1.4](http://stedolan.github.io/jq/download/) or later (for stack-diff)
 
+### Optional Packages
+
+* [colordiff](https://www.colordiff.org/) to show stack-diff in color
+* [icdiff](https://github.com/jeffkaufman/icdiff) to show stack-diff in color and side-by-side
+
 ### Installation
 
 As shown below, you may simply clone the GitHub repo and source the files required.

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -840,7 +840,9 @@ _bma_stack_diff_template() {
   if ! aws cloudformation describe-stacks --stack-name "$stack" 1>/dev/null; then
     return 1;
   fi
-  if [ "x$( type -P colordiff )" != "x" ]; then
+  if [ "x$( command -v icdiff )" != "x" ]; then
+    local DIFF_CMD=icdiff
+  elif [ "x$( command -v colordiff )" != "x" ]; then
     local DIFF_CMD=colordiff
   else
     local DIFF_CMD=diff
@@ -876,7 +878,9 @@ _bma_stack_diff_params() {
   if [ ! -f "$params" ]; then
     return 1
   fi
-  if [ "x$( type -P colordiff )" != "x" ]; then
+  if [ "x$( command -v icdiff )" != "x" ]; then
+    local DIFF_CMD=icdiff
+  elif [ "x$( command -v colordiff )" != "x" ]; then
     local DIFF_CMD=colordiff
   else
     local DIFF_CMD=diff

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -840,9 +840,9 @@ _bma_stack_diff_template() {
   if ! aws cloudformation describe-stacks --stack-name "$stack" 1>/dev/null; then
     return 1;
   fi
-  if [ "x$( command -v icdiff )" != "x" ]; then
+  if command -v icdiff; then
     local DIFF_CMD=icdiff
-  elif [ "x$( command -v colordiff )" != "x" ]; then
+  elif command -v colordiff; then
     local DIFF_CMD=colordiff
   else
     local DIFF_CMD=diff
@@ -878,9 +878,9 @@ _bma_stack_diff_params() {
   if [ ! -f "$params" ]; then
     return 1
   fi
-  if [ "x$( command -v icdiff )" != "x" ]; then
+  if command -v icdiff; then
     local DIFF_CMD=icdiff
-  elif [ "x$( command -v colordiff )" != "x" ]; then
+  elif command -v colordiff; then
     local DIFF_CMD=colordiff
   else
     local DIFF_CMD=diff


### PR DESCRIPTION
This PR updates the stack-diff function in a couple of simple ways.

* it corrects a problem on macOS where the `type` command doesn't have a "-p" flag.  Therefor the `stack-diff` function was always using plane `diff` even if `colordiff` was installed and available.
* it adds the ability to use the `icdiff` program, if available.  This has the affect of making the diff output colored and side-by-side.
* Finally, it adds more detail to the README to show the user it's possible to make the stack-diff output
more pretty.  I wasn't sure where to put this so you might want to reformat it to make it fit the rest of the documentation better.