### PR TITLE
Update build scripts to use $BMA_HOME

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,7 +1,7 @@
 # DO NOT MANUALLY MODIFY THIS FILE.
 # Use 'scripts/build' to regenerate if required.
 
-bma_path="${HOME}/.bash-my-aws"
+bma_path="${BMA_HOME:-$HOME}/.bash-my-aws"
 _bma_asgs_completion() {
   local command="$1"
   local word="$2"

--- a/scripts/build
+++ b/scripts/build
@@ -41,7 +41,7 @@ funcs_after_bma=$(compgen -A function)
 exclusions=('region')
 
 for fnc in $(echo "${funcs_before_bma}" "${funcs_after_bma}" "${exclusions}" | tr ' ' '\n' | LC_ALL=C sort | uniq -u); do
-  echo "alias $fnc='${project_root}/bin/bma $fnc'" >> "$aliases_destination"
+  echo "alias $fnc='\${BMA_HOME:-\$HOME/.bash-my-aws}/bin/bma $fnc'" >> "$aliases_destination"
 done;
 
 

--- a/scripts/build-completions
+++ b/scripts/build-completions
@@ -6,7 +6,7 @@ cat <<EOF
 # DO NOT MANUALLY MODIFY THIS FILE.
 # Use 'scripts/build' to regenerate if required.
 
-bma_path="\${HOME}/.bash-my-aws"
+bma_path="\${BMA_HOME:-\$HOME}/.bash-my-aws"
 EOF
 
 # load in all the completions from scripts/completions


### PR DESCRIPTION
## Why 

Noticed changes to the default location. See https://github.com/bash-my-aws/bash-my-aws/pull/319
- `bash_completion.sh` is hardcoded to `"\${HOME}/.bash-my-aws"`
- If you re-run the build script, it will overwrite the `aliases` with resolved `project_root`. 

# How

- Update the alias generation script to use `'\${BMA_HOME:-\$HOME/.bash-my-aws}` 
- Update the completion generation script to use `'\${BMA_HOME:-\$HOME/.bash-my-aws}` 
- Reran the build script to generate the `bash_completion.sh` and `aliases`





 