### PR TITLE
Improve handling of ssh key path in instance_ssh()

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -258,7 +258,7 @@ instance-ssh() {
 
     ssh                                    \
       -t                                   \
-      -i "${BMA_SSH_DIR:-~/.ssh/}$keyname" \
+      -i "${BMA_SSH_DIR:-~/.ssh}/$keyname" \
       -o LogLevel=error                    \
       -o StrictHostKeyChecking=no          \
       -o UserKnownHostsFile=/dev/null      \


### PR DESCRIPTION
As per #324 , this PR proposes a tiny change to the handling of the ssh key path within the `instance_ssh()` function.

The change is literally from this:

```
-i "${BMA_SSH_DIR:-~/.ssh/}$keyname"
```

to this

```
-i "${BMA_SSH_DIR:-~/.ssh}/$keyname"
```

The rationale is that if `BMA_SSH_DIR` is missing a trailing slash, this will ensure that one is present. If `BMA_SSH_DIR` does have a trailing slash, then a non-fatal double-slash will be present (i.e. `/path/to/BMA_SSH_DIR//keyname`) and the connection will still work. Either way, the default behaviour of `~/.ssh/$keyname` remains intact.

With the current code, a `BMA_SSH_DIR` without a trailing slash results in e.g. `/path/to/BMA_SSH_DIRkeyname` which will obviously fail.