### PR TITLE
Improve efficiency and consistency of instance-ssh()

### DIFF
--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -233,37 +233,33 @@ instance-ssh() {
   #
   #     USAGE: instance-ssh [login] [instance-id] [instance-id]
 
+  local ssh_user instance_id keyname private_ip instance_name instance_default_user
   if [[ $1 != *i-* ]]; then
-    local user=${1}
+    ssh_user="${1}"
     shift
   fi
-  local instance_ids=$(skim-stdin "$@")
-  if [[ -z $instance_ids ]] ; then
-    echo "Usage: $FUNCNAME [login] [instance-id] [instance-id]"
+  instance_ids=$(skim-stdin "$@")
+  if [[ -z "${instance_ids}" ]] ; then
+    __bma_usage "[login] [instance-id] [instance-id]"
     return 1
   fi
 
   exec </dev/tty # reattach keyboard to STDIN
 
-  for instance_id in $instance_ids; do
-    local instance_details="$(instance-ssh-details $instance_id)"
-    local instance_id=$(echo $instance_details | awk '{print $1}')
-    local keyname=$(echo $instance_details | awk '{print $2}')
-    local private_ip=$(echo $instance_details | awk '{print $3}')
-    local instance_name=$(echo $instance_details | awk '{print $4}')
-    local instance_default_user=$(echo $instance_details | awk '{print $5}')
+  for instance_id in ${instance_ids}; do
+    read -r instance_id keyname private_ip instance_name instance_default_user < <(instance-ssh-details "${instance_id}")
 
-    local USERNAME=${user:-${instance_default_user:-${AWS_DEFAULT_USER:-root}}}
+    ssh_user="${ssh_user:-${instance_default_user:-${AWS_DEFAULT_USER:-root}}}"
     echo "Connecting to EC2 Instance $instance_id '$instance_name'" 2>&1
 
-    ssh                                    \
-      -t                                   \
-      -i "${BMA_SSH_DIR:-~/.ssh}/$keyname" \
-      -o LogLevel=error                    \
-      -o StrictHostKeyChecking=no          \
-      -o UserKnownHostsFile=/dev/null      \
-      -l "$USERNAME"                       \
-      "$private_ip"
+    ssh                                      \
+      -t                                     \
+      -i "${BMA_SSH_DIR:-~/.ssh}/${keyname}" \
+      -o LogLevel=error                      \
+      -o StrictHostKeyChecking=no            \
+      -o UserKnownHostsFile=/dev/null        \
+      -l "${ssh_user}"                       \
+      "${private_ip}"
   done
 }
 


### PR DESCRIPTION
Hi,
as per the discussion in #324 , I'd like to propose the following changes to `import-ssh()`:

* Declare all local variables on a single line.  This satisfies Shellcheck and reduces repeated `local x=y` visual clutter
* Switch the usage output to use `__bma_usage()`
* Rename `user` and `USERNAME` to `ssh_user`.  This varname is more descriptive, and by avoiding UPPERCASE, we avoid a potential collision in the environment "scope"
* Replace the multiple `echo | awk` sequences with a single `read -r` multiple variable assignment.  This is the main efficiency improvement provided by this PR.  This is, also, portable across the versions of `ksh`, `bash` and `zsh` that I've tested with.

I have increased the number of vars that use the optional brace syntax, but have not completely done so throughout.  I personally prefer braces-by-default so that all vars, arrays, expansions etc have a consistent visual look.  This is especially handy when you don't have syntax highlighting available, as the braces improves readability.  Happy to complete 'the look' or revert based on your tastes @mbailey .

Potential code-golfing remains e.g.

```
  if [[ $1 != *i-* ]]; then
    ssh_user="${1}"
    shift
  fi
```

Could be something like:

```
[[ $1 != *i-* ]] && ssh_user="${1}"; shift 1
```

and

```
  if [[ -z "${instance_ids}" ]] ; then
    __bma_usage "[login] [instance-id] [instance-id]"
    return 1
  fi
```

Could be something like:

```
[[ -z "${instance_ids}" ]] && __bma_usage "[login] [instance-id] [instance-id]"; return 1
```

This second example would be consistent with other functions like `instance-ssh-details()`.