### PR TITLE
Fixed a few references to standard path so BMA_HOME will work instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,12 @@ a changes that would eliminate any shell compatibility problems without compromi
 the functionaility, simplicity and discoverability of the project. Massive thanks
 to [@ninth-dev](https://github.com/ninth-dev) for this.
 
+```Shell
     # bash users may source the functions instead of loading the aliases
-    if [ -d ${HOME}/.bash-my-aws ]; then
-      for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
+    if [ -d ${BMA_HOME:-$HOME/.bash-my-aws} ]; then
+      for f in ${BMA_HOME:-$HOME/.bash-my-aws}/lib/*-functions; do source $f; done
     fi
+```
 
 
 ## Usage

--- a/bin/bma
+++ b/bin/bma
@@ -13,7 +13,7 @@
 #
 # Assumes you have installed bash-my-aws to standard location
 
-for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
+for f in "${BMA_HOME:-$HOME/.bash-my-aws}"/lib/*-functions; do source $f; done
 
 # Disable awcli client side pager
 #

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,20 +157,20 @@ As shown below, you may simply clone the GitHub repo and source the files requir
 (You should probably fork it instead to keep your customisations)
 
 ```Shell
-$ git clone https://github.com/bash-my-aws/bash-my-aws.git ~/.bash-my-aws
+$ git clone https://github.com/bash-my-aws/bash-my-aws.git ${BMA_HOME:-$HOME/.bash-my-aws}
 ```
 
 Put the following in your shell's startup file:
 
 ```Shell
-export PATH="$PATH:$HOME/.bash-my-aws/bin"
-source ~/.bash-my-aws/aliases
+export PATH="$PATH:${BMA_HOME:-$HOME/.bash-my-aws}/bin"
+source ${BMA_HOME:-$HOME/.bash-my-aws}/aliases
 
 # For ZSH users, uncomment the following two lines:
 # autoload -U +X compinit && compinit
 # autoload -U +X bashcompinit && bashcompinit
 
-source ~/.bash-my-aws/bash_completion.sh
+source ${BMA_HOME:-$HOME/.bash-my-aws}/bash_completion.sh
 ```
 
 !!! note "Why use shell aliases?"
@@ -184,11 +184,13 @@ source ~/.bash-my-aws/bash_completion.sh
     the functionaility, simplicity and discoverability of the project. Massive thanks
     to [@ninth-dev](https://github.com/ninth-dev) for this.
 
-
+```Shell
         # bash users may source the functions instead of loading the aliases
-        if [ -d ${HOME}/.bash-my-aws ]; then
+        if [ -d ${BMA_HOME:-$HOME/.bash-my-aws} ]; then
+          for f in ${BMA_HOME:-$HOME/.bash-my-aws}/lib/*-functions; do source $f; done
           for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
         fi
+```
 
 ## Usage
 

--- a/test/exercise-functions.sh
+++ b/test/exercise-functions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-source ~/.bash-my-aws/bin/bma
+      for f in ${BMA_HOME:-$HOME/.bash-my-aws}/lib/*-functions; do source $f; done
+source "${BMA_HOME:-$HOME/.bash-my-aws}"/bin/bma
 
 # init function override for aws
 function aws() {


### PR DESCRIPTION
Found a few reference to ~/.bash-my-aws which should instead use ${BMA_HOME:-$HOME/.bash-my-aws}