### PR TITLE
Add elb tag reading functions

### DIFF
--- a/lib/elb-functions
+++ b/lib/elb-functions
@@ -156,3 +156,44 @@ elb-azs() {
       ]"              |
     column -s$'\t' -t
 }
+
+elb-tags() {
+
+  # List tags applied ELB(s)
+  #
+  #     USAGE: elb-tags elb-id [elb-id]
+
+  local elb_ids=$(skim-stdin "$@")
+  [[ -z $elb_ids ]] && __bma_usage "elb-id [elb-id]" && return 1
+
+  aws elb describe-tags                            \
+    --load-balancer-names $elb_ids                 \
+    --output text                                  \
+    --query "
+      TagDescriptions[].[
+        LoadBalancerName,
+        join(' ', [Tags[].[join('=',[Key,Value])][]][])
+      ]
+      "            |
+  column -s$'\t' -t
+}
+
+elb-tag() {
+
+  # List named tag on ELB(s)
+  #
+  #     USAGE: elb-tag key elb-id [elb-id]
+
+  local key="$1"
+  shift
+  local elb_ids=$(skim-stdin "$@")
+  [[ -z $key ]] && __bma_usage "key elb-id [elb-id]" && return 1
+
+  aws elb describe-tags                          \
+    --load-balancer-names $elb_ids               \
+    --output text                                \
+    --query "TagDescriptions[].[
+       [ LoadBalancerName, Tags[?Key=='$key'][Key,Value][] ][]
+     ][]" |
+  column -s$'\t' -t
+}


### PR DESCRIPTION
Hi I had to do some ELB investigations in the last few days so I created these functions `elb-tag` and `elb-tags` to view ... wait for it ... elb tags.

They are direct copies of instance-tag and instance-tags. The only big difference is aws elb describe-tags doesn't support the --filter argument so going `elbs | elb-tag $tagname` would not filter out items without that tagname like I suspect instance-tag does. There might be a way to do similar filtering in jmespath if that's a deal-breaker, but I'm not too familiar with it.

Thought this might be helpful to share back. LMK what you think.