### PR TITLE
specify keyTypes explicitly, otherwise aws acm list-certificates doesn't include all certs

### DIFF
--- a/lib/cert-functions
+++ b/lib/cert-functions
@@ -14,6 +14,7 @@ certs() {
   [[ -n ${include_arn:-} ]] && include_arn_bit="CertificateArn,"
   local retrieved_cert_arns=$(
     aws acm list-certificates      \
+      --includes keyTypes=RSA_1024,RSA_2048,EC_secp384r1,EC_prime256v1,EC_secp521r1,RSA_3072,RSA_4096 \
       --output text                \
       --query "
         CertificateSummaryList[${cert_arns:+?contains(['${cert_arns// /"','"}'], CertificateArn)}].[


### PR DESCRIPTION
See https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-list.html
which says:

> By default, only certificates with keyTypes RSA_1024 or RSA_2048 and with at least one specified domain are returned. To see other certificates that you control, such as domainless certificates or certificates using a different algorithm or bit size, provide the --includes parameter as shown in the following example. The parameter allows you to specify a member of the [Filters](https://docs.aws.amazon.com/acm/latest/APIReference/API_Filters.html) structure.

For example, I have an ACM cert that does not get listed because it is RSA_4096.

The list of `keyTypes` I've obtained by running `aws acm list-certificates --includes keyTypes=blah` which spits out:

> An error occurred (ValidationException) when calling the ListCertificates operation: 1 validation error detected: Value '[blah]' at 'includes.keyTypes' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [RSA_1024, RSA_2048, EC_secp384r1, EC_prime256v1, EC_secp521r1, RSA_3072, RSA_4096]]