### PR TITLE
scripts/build: correct path when BMA_HOME is set

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,7 +1,7 @@
 # DO NOT MANUALLY MODIFY THIS FILE.
 # Use 'scripts/build' to regenerate if required.
 
-bma_path="${BMA_HOME:-$HOME}/.bash-my-aws"
+bma_path="${BMA_HOME:-$HOME/.bash-my-aws}"
 _bma_asgs_completion() {
   local command="$1"
   local word="$2"

--- a/scripts/build-completions
+++ b/scripts/build-completions
@@ -6,7 +6,7 @@ cat <<EOF
 # DO NOT MANUALLY MODIFY THIS FILE.
 # Use 'scripts/build' to regenerate if required.
 
-bma_path="\${BMA_HOME:-\$HOME}/.bash-my-aws"
+bma_path="\${BMA_HOME:-\$HOME/.bash-my-aws}"
 EOF
 
 # load in all the completions from scripts/completions


### PR DESCRIPTION
This fixes tab completion when `BMA_HOME` is set. Corrects reference to https://github.com/bash-my-aws/bash-my-aws/blob/c85a77202fee8a41416f0ec455d48d8f64b677f9/bin/bma#L16