### PR TITLE
describe-stack-resources maxes out at 100, use list-stack-resources instead

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -417,10 +417,10 @@ stack-resources() {
   local stack
   for stack in $stacks; do
     stack=$(_bma_stack_name_arg "$stack")
-    aws cloudformation describe-stack-resources                       \
+    aws cloudformation list-stack-resources                           \
       --stack-name $(_bma_stack_name_arg "$stack")                    \
       --output "${BMA_OUTPUT_AWS:-text}" \
-      --query "StackResources[].{
+      --query "StackResourceSummaries[].{
                PhysicalResourceId: PhysicalResourceId,
                ResourceType: ResourceType,
                ResourceStatus: ResourceStatus,


### PR DESCRIPTION
`stack-resources` which uses `aws cloudformation describe-stack-resources` lists only the first 100 resources.
AWS CLI documentation recommends to use `aws cloudformation list-stack-resources` instead.

https://docs.aws.amazon.com/cli/latest/reference/cloudformation/describe-stack-resources.html