### PR TITLE
Remove deprecated function keyword; it causes confused mkdocs output

### DIFF
--- a/lib/azure-functions
+++ b/lib/azure-functions
@@ -472,15 +472,15 @@ ad-users() {
   # columnise
 }
 
-function ad-user-upns() {
+ad-user-upns() {
   ad-users $@ | cut -f1
 }
 
-function ad-user-upns() {
+ad-user-upns() {
   ad-users $@ | cut -f2
 }
 
-function ad-user-names() {
+ad-user-names() {
   ad-users $@ | cut -f3
 }
 
@@ -664,7 +664,7 @@ ad-app-owners() {
   #   LC_ALL=C sort -t$'\t' -b -k 3
 }
 
-function connectors() {
+connectors() {
 
   # Usage: connectors REMOTE_FILTER LOCAL_FILTER
   #
@@ -690,7 +690,7 @@ function connectors() {
     sort -k 3
 }
 
-function connector-groups() {
+connector-groups() {
 
   # Usage: connector-groups REMOTE_FILTER LOCAL_FILTER
   #
@@ -716,7 +716,7 @@ function connector-groups() {
     sort -k 2
 }
 
-function connector-group-apps() {
+connector-group-apps() {
 
   # Usage: connector-group-apps CONNECTOR_GROUP [CONNECTOR_GROUP]
 
@@ -742,7 +742,7 @@ function connector-group-apps() {
   done
 }
 
-function connector-group-members() {
+connector-group-members() {
 
   # Usage: connector-group-apps CONNECTOR_GROUP [CONNECTOR_GROUP]
 

--- a/test/exercise-functions.sh
+++ b/test/exercise-functions.sh
@@ -4,21 +4,21 @@
 source "${BMA_HOME:-$HOME/.bash-my-aws}"/bin/bma
 
 # init function override for aws
-function aws() {
+aws() {
   echo "aws $@"
 }
 
 # override to make output prettier
-function base64() {
+base64() {
   cat
 }
 
 # Don't run this one
-function stack-tail() {
+stack-tail() {
   :
 }
 
-function cmd() {
+cmd() {
   echo "# Command: $@"
   $@
   echo


### PR DESCRIPTION
Hey Mike,
here's a hopefully quick and simple one.  I noticed that the docs had unexpected headings that look like this:

![image](https://github.com/bash-my-aws/bash-my-aws/assets/1708071/973ac309-0cfb-4210-9eb3-b2f8d2794e6f)

It looks like this traces back to the use of this style of function declaration:

```
function func_name() {
```

This optional style is `bash` specific, non-portable, and generally considered to be deprecated.

There is a gotcha:  The `function` keyword can be useful for a particular edge case: preventing collisions with same-named aliases.  In 99% of scenarios this isn't an issue - but `bash-my-aws` is the one project I can think of where it could potentially be.  I can't see a reason for this edge-case to block this particular change.

Possible follow up tasks for someone who isn't me :) :

* Write a test to ensure that this function declaration style isn't committed again in the future
* Consider a code style guide, https://chromium.googlesource.com/chromiumos/docs/+/HEAD/styleguide/shell.md is a good starting point
* If this edge-case is an issue, require a comment (style guide) that the test can deal with

Cheers!