### PR TITLE
adding a bucket-remove-all-objects-versions function

### DIFF
--- a/lib/s3-functions
+++ b/lib/s3-functions
@@ -112,7 +112,39 @@ bucket-remove-force() {
     local bucket
     for bucket in $buckets; do
       aws s3 rb --force "s3://${bucket}"
+      if [[ $? -ne 0 ]]
+      then
+        echo "Remove bucket failed, trying to delete object versions first (this may take a while)..."
+        bucket-remove-all-objects-versions ${bucket}
+        aws s3 rb --force "s3://${bucket}"
+      fi
     done
   fi
 }
 
+bucket-remove-all-objects-versions() {
+
+  local buckets=$(skim-stdin "$@")
+  [[ -z "$buckets" ]] && __bma_usage "bucket [bucket]" && return 1
+
+  local bucket
+  for bucket in $buckets; do
+    echo "Removing all versions from $bucket"
+
+    versions=`aws s3api list-object-versions --bucket $bucket |jq '.Versions'`
+    let count=`echo $versions |jq 'length'`-1
+
+    if [ $count -gt -1 ]; then
+            echo "removing files"
+            for i in $(seq 0 $count); do
+                    echo -ne "${i} out of ${count}\r"
+                    key=`echo $versions | jq .[$i].Key |sed -e 's/\"//g'`
+                    versionId=`echo $versions | jq .[$i].VersionId |sed -e 's/\"//g'`
+                    aws s3api delete-object --bucket $bucket --key '$key' --version-id $versionId > /dev/null
+            done
+            echo -ne '\n'
+    fi
+
+ done
+
+}


### PR DESCRIPTION
bucket-remove-force fails if the bucket contains versions.

This adds delete of each object versions, can be very long so I added a small counter display.

Example of run:
```
bucket-remove-force mybuckettobetrashed
You are about to delete all objects from and remove the following buckets:
mybuckettobetrashed  2023-08-11T14:24:00+00:00
Are you sure you want to continue? y
remove_bucket failed: s3://mybuckettobetrashed An error occurred (BucketNotEmpty) when calling the DeleteBucket operation: The bucket you tried to delete is not empty. You must delete all versions in the bucket.
Remove bucket failed, trying to delete object versions first (this may take a while)...
Removing all versions from mybuckettobetrashed
removing files
93 out of 1761
```